### PR TITLE
Add test scripts for convenience and to maintain idiomatic npm project configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "lib/bulbs-elements/bulbs-elements.js",
   "repository": "git@github.com:theonion/bulbs-elements.git",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "karma start --single-run",
+    "karma": "karma start"
   },
   "author": "Onion Product Team <webtech@theonion.com>",
   "license": "UNLICENSED",


### PR DESCRIPTION
This is common for npm packages. Even though we have a convention of using scripts, we can still leverage npm to maintain the [principal of least surprise](https://en.wikipedia.org/wiki/Principle_of_least_astonishment).