### PR TITLE
Campaign display fixes

### DIFF
--- a/elements/campaign-display/fields/campaign-field.js
+++ b/elements/campaign-display/fields/campaign-field.js
@@ -3,7 +3,11 @@ const CampaignField = {
 
   actions: {
     handleFetchComplete(state, response) {
-      return response;
+      state.clickthrough_url = response.clickthrough_url;
+      state.image_id = response.image_id;
+      state.image_url = response.image_url;
+      state.name = response.name;
+      return state;
     },
   },
 };

--- a/elements/campaign-display/fields/campaign-field.test.js
+++ b/elements/campaign-display/fields/campaign-field.test.js
@@ -18,8 +18,15 @@ describe('<campaign-display> CampaignField', () => {
 
   describe('handleFetchComplete', () => {
     it('returns the response', () => {
-      let state = subject.actions.handleFetchComplete({}, { data: 'test' });
-      expect(state.data).to.equal('test');
+      let state = {};
+      let response = {
+        clickthrough_url: 'clickthrough_url',
+        image_id: 'image_id',
+        image_url: 'image_url',
+        name: 'name',
+      };
+      subject.actions.handleFetchComplete(state, response);
+      expect(state).to.eql(response);
     });
   });
 });

--- a/elements/campaign-display/fields/campaign-request-field.js
+++ b/elements/campaign-display/fields/campaign-request-field.js
@@ -20,7 +20,6 @@ const CampaignRequestField = {
     fetchCampaignSuccess(state, response, store) {
       state.requestInFlight = false;
       store.actions.handleFetchComplete(response);
-      return state;
     },
 
     fetchCampaignFailure(state, response) {

--- a/elements/campaign-display/fields/campaign-request-field.test.js
+++ b/elements/campaign-display/fields/campaign-request-field.test.js
@@ -39,7 +39,8 @@ describe('<campaign-display> CampaignRequestField', () => {
 
   describe('fetchCampaignSuccess', () => {
     it('sets requestInFlight to false', () => {
-      let state = subject.actions.fetchCampaignSuccess({}, testUrl, mockStore);
+      let state = {};
+      subject.actions.fetchCampaignSuccess(state, testUrl, mockStore);
       expect(state.requestInFlight).to.equal(false);
     });
 

--- a/lib/bulbs-elements/store/store.js
+++ b/lib/bulbs-elements/store/store.js
@@ -73,7 +73,11 @@ function dispatchFunction (store, action, payload) {
 
   nextState[action.fieldName] = action(nextFieldValue, payload, store);
 
-  store.state = nextState;
+  // HACK : workaround for broken state modification
+  if (typeof nextState[action.fieldName] !== 'undefined') {
+    store.state = nextState;
+  }
+
   deliverSubscriptions(store);
 
   if (DEBUG) {


### PR DESCRIPTION
Hack for displaying campaign data properly when using separate fields for request v. data.

**Note**: Remove this once we fix the way `store.js` works.