### PR TITLE
<campaign-display> <DfpPixel> with render callback passed in as string

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,4 +90,14 @@ Bulbs Elements comes with code generators to help you develop components.
 
 ### Testing
 
+To do a single test run:
+```bash
+$ npm test
+```
+
+To start continuous testing:
+```bash
+$ npm run karma
+```
+
 ### Examples

--- a/elements/campaign-display/campaign-display-examples.js
+++ b/elements/campaign-display/campaign-display-examples.js
@@ -5,6 +5,7 @@ let examples = {
       render() {
         return `
           <campaign-display
+            placement="my-custom-placement"
             src="http://localhost:8080/fixtures/campaign-display/campaign.json"
             preamble-text="Presented by"
           >
@@ -17,6 +18,7 @@ let examples = {
       render() {
         return `
           <campaign-display
+            placement="my-custom-placement"
             src="http://localhost:8080/fixtures/campaign-display/campaign.json"
             preamble-text="Sponsored by"
             name-only
@@ -30,6 +32,7 @@ let examples = {
       render() {
         return `
           <campaign-display
+            placement="my-custom-placement"
             src="http://localhost:8080/fixtures/campaign-display/campaign.json"
             preamble-text="Sponsored by"
             image-only

--- a/elements/campaign-display/campaign-display.js
+++ b/elements/campaign-display/campaign-display.js
@@ -13,6 +13,7 @@ import CampaignDisplayRoot from './components/campaign-display-root';
 class CampaignDisplay extends BulbsElement {
   constructor (props) {
     invariant(!!props.src, 'campaign-display component requires a src');
+    invariant(!!props.placement, 'campaign-display component requires a placement');
     super(props);
   }
 
@@ -38,6 +39,7 @@ Object.assign(CampaignDisplay, {
   propTypes: {
     logoOnly: PropTypes.string,
     nameOnly: PropTypes.string,
+    placement: PropTypes.string.isRequired,
     preambleText: PropTypes.string,
     src: PropTypes.string.isRequired,
   },

--- a/elements/campaign-display/campaign-display.scss
+++ b/elements/campaign-display/campaign-display.scss
@@ -1,3 +1,10 @@
 campaign-display {
   display: block;
+
+  .campaign-display-logo {
+
+    img {
+      width: 100%;
+    }
+  }
 }

--- a/elements/campaign-display/campaign-display.test.js
+++ b/elements/campaign-display/campaign-display.test.js
@@ -5,6 +5,7 @@ import fetchMock from 'fetch-mock';
 
 describe('<campaign-display>', () => {
   let subject;
+  let placement;
   let props;
   let shallowRenderer;
   let src;
@@ -13,23 +14,31 @@ describe('<campaign-display>', () => {
     // We sould investigate if this is an issue with lib/bulbs-elements/store/store.js:60
     CampaignDisplay.prototype.setState = chai.spy();
 
+    placement = 'top';
     src = 'http://example.com';
     props = {
       src,
       clickthrough_url: 'http://example.com/clickthrough',
       image_id: 'http://example.com/image.jpg',
       name: 'Test Campaign',
+      placement,
     };
     fetchMock.mock(src, props);
     shallowRenderer = createRenderer();
-    shallowRenderer.render(<CampaignDisplay src={src} />);
+    shallowRenderer.render(<CampaignDisplay src={src} placement={placement} />);
     subject = new CampaignDisplay(props);
   });
 
-  it('requires a src', () => {
+  it('should require a src', () => {
     expect(() => {
-      new CampaignDisplay({}); // eslint-disable-line
+      new CampaignDisplay({ placement: 'top' }); // eslint-disable-line
     }).to.throw('campaign-display component requires a src');
+  });
+
+  it('should require a placement', function () {
+    expect(() => {
+      new CampaignDisplay({ src: 'some/src '}); // eslint-disable-line
+    }).to.throw('campaign-display component requires a placement');
   });
 
   describe('initialDispatch', () => {

--- a/elements/campaign-display/components/campaign-display-root.js
+++ b/elements/campaign-display/components/campaign-display-root.js
@@ -2,6 +2,7 @@ import React, { PropTypes, Component } from 'react';
 import Logo from './logo';
 import Preamble from './preamble';
 import SponsorName from './sponsor-name';
+import DfpPixel from './dfp-pixel';
 
 class CampaignDisplayRoot extends Component {
   constructor(props) {
@@ -11,6 +12,7 @@ class CampaignDisplayRoot extends Component {
   renderDefaultComponent() {
     return (
       <div className='campaign-display'>
+        <DfpPixel campaignId={this.props.campaign.id} placement={this.props.placement} />
         <Logo {...this.props.campaign} />
         <Preamble text={this.props.preambleText}/>
         <SponsorName {...this.props.campaign} />
@@ -20,6 +22,7 @@ class CampaignDisplayRoot extends Component {
   renderLogoComponent() {
     return (
       <div className='campaign-display'>
+        <DfpPixel campaignId={this.props.campaign.id} placement={this.props.placement} />
         <Preamble text={this.props.preambleText}/>
         <Logo {...this.props.campaign} />
       </div>);
@@ -28,6 +31,7 @@ class CampaignDisplayRoot extends Component {
   renderNameComponent() {
     return (
       <div className='campaign-display'>
+        <DfpPixel campaignId={this.props.campaign.id} placement={this.props.placement} />
         <Preamble text={this.props.preambleText}/>
         <SponsorName {...this.props.campaign} />
       </div>);
@@ -55,6 +59,7 @@ CampaignDisplayRoot.propTypes = {
   campaign: PropTypes.object,
   logoOnly: PropTypes.bool,
   nameOnly: PropTypes.bool,
+  placement: PropTypes.string,
   preambleText: PropTypes.string,
 };
 

--- a/elements/campaign-display/components/campaign-display-root.test.js
+++ b/elements/campaign-display/components/campaign-display-root.test.js
@@ -4,23 +4,28 @@ import CampaignDisplayRoot from './campaign-display-root';
 import Logo from './logo';
 import Preamble from './preamble';
 import SponsorName from './sponsor-name';
+import DfpPixel from './dfp-pixel';
 
 describe('<campaign-display> <CampaignDisplayRoot>', () => {
   let shallowRenderer = createRenderer();
   let subject;
   let props;
   let campaign;
+  let placement;
   let preambleText;
 
   beforeEach(() => {
+    placement = 'top';
     preambleText = 'Presented by';
     campaign = {
+      id: 123,
       image_id: 1,
       clickthrough_url: 'http://example.com/campaign',
       name: 'Test Campaign',
     };
     props = {
       campaign,
+      placement,
       preambleText,
     };
   });
@@ -31,12 +36,14 @@ describe('<campaign-display> <CampaignDisplayRoot>', () => {
       subject = shallowRenderer.getRenderOutput();
     });
 
-    it('renders the logo and name, each wrapped in a link to the clickthrough_url', () => {
-      let logo = subject.props.children[0];
-      let preamble = subject.props.children[1];
-      let sponsorName = subject.props.children[2];
+    it('renders the pixel, logo, and name, each wrapped in a link to the clickthrough_url', () => {
+      let pixel = subject.props.children[0];
+      let logo = subject.props.children[1];
+      let preamble = subject.props.children[2];
+      let sponsorName = subject.props.children[3];
 
-      expect(subject.props.children.length).to.equal(3);
+      expect(subject.props.children.length).to.equal(4);
+      expect(pixel.type).to.be.equal(DfpPixel);
       expect(logo.type).to.be.equal(Logo);
       expect(preamble.type).to.be.equal(Preamble);
       expect(sponsorName.type).to.be.equal(SponsorName);
@@ -46,44 +53,50 @@ describe('<campaign-display> <CampaignDisplayRoot>', () => {
   context('with logo-only set to true', () => {
     beforeEach(() => {
       campaign = {
+        id: 123,
         clickthrough_url: 'http://example.com/campaign',
         image_id: 1,
       };
       props = {
         campaign,
         logoOnly: true,
+        placement,
         preambleText,
       };
       shallowRenderer.render(<CampaignDisplayRoot {...props}/>);
       subject = shallowRenderer.getRenderOutput();
     });
 
-    it('only renders the preamble and the logo', () => {
-      expect(subject.props.children.length).to.equal(2);
-      expect(subject.props.children[0].type).to.equal(Preamble);
-      expect(subject.props.children[1].type).to.equal(Logo);
+    it('only renders the pixel, preamble and logo', () => {
+      expect(subject.props.children.length).to.equal(3);
+      expect(subject.props.children[0].type).to.equal(DfpPixel);
+      expect(subject.props.children[1].type).to.equal(Preamble);
+      expect(subject.props.children[2].type).to.equal(Logo);
     });
   });
 
   context('with name-only set to true', () => {
     beforeEach(() => {
       campaign = {
+        id: 123,
         clickthrough_url: 'http://example.com/campaign',
         image_id: 1,
       };
       props = {
         campaign,
         logoOnly: true,
+        placement,
         preambleText,
       };
       shallowRenderer.render(<CampaignDisplayRoot {...props}/>);
       subject = shallowRenderer.getRenderOutput();
     });
 
-    it('only renders the preamble and the name', () => {
-      expect(subject.props.children.length).to.equal(2);
-      expect(subject.props.children[0].type).to.equal(Preamble);
-      expect(subject.props.children[1].type).to.equal(Logo);
+    it('only renders the pixel, preamble, and name', () => {
+      expect(subject.props.children.length).to.equal(3);
+      expect(subject.props.children[0].type).to.equal(DfpPixel);
+      expect(subject.props.children[1].type).to.equal(Preamble);
+      expect(subject.props.children[2].type).to.equal(Logo);
     });
   });
 });

--- a/elements/campaign-display/components/campaign-display-root.test.js
+++ b/elements/campaign-display/components/campaign-display-root.test.js
@@ -37,16 +37,12 @@ describe('<campaign-display> <CampaignDisplayRoot>', () => {
     });
 
     it('renders the pixel, logo, and name, each wrapped in a link to the clickthrough_url', () => {
-      let pixel = subject.props.children[0];
-      let logo = subject.props.children[1];
-      let preamble = subject.props.children[2];
-      let sponsorName = subject.props.children[3];
 
       expect(subject.props.children.length).to.equal(4);
-      expect(pixel.type).to.be.equal(DfpPixel);
-      expect(logo.type).to.be.equal(Logo);
-      expect(preamble.type).to.be.equal(Preamble);
-      expect(sponsorName.type).to.be.equal(SponsorName);
+      expect(subject.props.children[0].type).to.be.equal(DfpPixel);
+      expect(subject.props.children[1].type).to.be.equal(Logo);
+      expect(subject.props.children[2].type).to.be.equal(Preamble);
+      expect(subject.props.children[3].type).to.be.equal(SponsorName);
     });
   });
 

--- a/elements/campaign-display/components/dfp-pixel.js
+++ b/elements/campaign-display/components/dfp-pixel.js
@@ -1,0 +1,15 @@
+import React, { PropTypes } from 'react';
+
+export default function DfpPixel (props) {
+  return (
+    <div
+        data-ad-unit={ props.adUnitName }
+        data-targeting={ props.targetingParams }>
+    </div>
+  );
+};
+
+DfpPixel.propTypes = {
+  adUnitName: PropTypes.string.isRequired,
+  targetingParams: PropTypes.object,
+};

--- a/elements/campaign-display/components/dfp-pixel.js
+++ b/elements/campaign-display/components/dfp-pixel.js
@@ -1,20 +1,49 @@
-import React, { PropTypes } from 'react';
+import React, { Component, PropTypes } from 'react';
 
-export default function DfpPixel (props) {
-  let targeting = {
-    dfp_placement: props.placement,
-    dfp_campaign_id: props.campaignId,
-  };
+let findFunctionOnWindow = function (functionName) {
+  let methodNameParts = functionName.split('.');
+  let callback = methodNameParts.reduce((prev, curr) => prev[curr], window);
 
-  return (
-    <div
-        data-ad-unit="campaign-pixel"
-        data-targeting={ JSON.stringify(targeting) }>
-    </div>
-  );
+  if (typeof callback === 'function') {
+    return callback;
+  }
+
+  throw new Error(`Unable to find \`window.${functionName}\``);
+};
+
+let functionPropType = function (props, propName, componentName) {
+  try {
+    findFunctionOnWindow(props[propName]);
+  }
+  catch (e) {
+    return new Error(`Invalid prop \`${propName}\` supplied to \`${componentName}\`. Validation failed.`);
+  }
+};
+
+export default class DfpPixel extends Component {
+
+  componentDidMount () {
+    findFunctionOnWindow(this.props.onRender)(this.refs.container);
+  }
+
+  render () {
+    let targeting = {
+      dfp_placement: this.props.placement,
+      dfp_campaign_id: this.props.campaignId,
+    };
+
+    return (
+      <div
+          ref="container"
+          data-ad-unit="campaign-pixel"
+          data-targeting={ JSON.stringify(targeting) }>
+      </div>
+    );
+  }
 }
 
 DfpPixel.propTypes = {
   campaignId: PropTypes.number.isRequired,
+  onRender: functionPropType,
   placement: PropTypes.string.isRequired,
 };

--- a/elements/campaign-display/components/dfp-pixel.js
+++ b/elements/campaign-display/components/dfp-pixel.js
@@ -1,15 +1,20 @@
 import React, { PropTypes } from 'react';
 
 export default function DfpPixel (props) {
+  let targeting = {
+    dfp_placement: props.placement,
+    dfp_campaign_id: props.campaignId,
+  };
+
   return (
     <div
-        data-ad-unit={ props.adUnitName }
-        data-targeting={ props.targetingParams }>
+        data-ad-unit="campaign-pixel"
+        data-targeting={ targeting }>
     </div>
   );
-};
+}
 
 DfpPixel.propTypes = {
-  adUnitName: PropTypes.string.isRequired,
-  targetingParams: PropTypes.object,
+  campaignId: PropTypes.number.isRequired,
+  placement: PropTypes.string.isRequired,
 };

--- a/elements/campaign-display/components/dfp-pixel.js
+++ b/elements/campaign-display/components/dfp-pixel.js
@@ -9,7 +9,7 @@ export default function DfpPixel (props) {
   return (
     <div
         data-ad-unit="campaign-pixel"
-        data-targeting={ targeting }>
+        data-targeting={ JSON.stringify(targeting) }>
     </div>
   );
 }

--- a/elements/campaign-display/components/dfp-pixel.test.js
+++ b/elements/campaign-display/components/dfp-pixel.test.js
@@ -11,7 +11,7 @@ describe('<campaign-display> <DfpPixel>', () => {
 
     it('should always be "campaign-pixel"', function () {
 
-      shallowRenderer.render(<DfpPixel placement="junk" campaignId='1' />);
+      shallowRenderer.render(<DfpPixel placement='junk' campaignId={1} />);
 
       let html = shallowRenderer.getRenderOutput();
       expect(html.props['data-ad-unit']).to.equal('campaign-pixel');
@@ -23,7 +23,7 @@ describe('<campaign-display> <DfpPixel>', () => {
     it('should include ad unit placement', function () {
       let placement = 'top';
 
-      shallowRenderer.render(<DfpPixel campaignId='1' placement={ placement } />);
+      shallowRenderer.render(<DfpPixel campaignId={1} placement={ placement } />);
 
       let html = shallowRenderer.getRenderOutput();
       expect(html.props['data-targeting'].dfp_placement).to.equal(placement);
@@ -32,7 +32,7 @@ describe('<campaign-display> <DfpPixel>', () => {
     it('should require ad unit placement', function () {
       chai.spy.on(console, 'error');
 
-      shallowRenderer.render(<DfpPixel campaignId='1' />);
+      shallowRenderer.render(<DfpPixel campaignId={1} />);
 
       expect(console.error).to.have.been.called.with(
         'Warning: Failed propType: Required prop `placement` was not specified in `DfpPixel`.'
@@ -51,7 +51,7 @@ describe('<campaign-display> <DfpPixel>', () => {
     it('should require campaign id', function () {
       chai.spy.on(console, 'error');
 
-      shallowRenderer.render(<DfpPixel placement="junk" />);
+      shallowRenderer.render(<DfpPixel placement='junk' />);
 
       expect(console.error).to.have.been.called.with(
         'Warning: Failed propType: Required prop `campaignId` was not specified in `DfpPixel`.'

--- a/elements/campaign-display/components/dfp-pixel.test.js
+++ b/elements/campaign-display/components/dfp-pixel.test.js
@@ -7,9 +7,18 @@ describe('<campaign-display> <DfpPixel>', () => {
 
   let shallowRenderer = createRenderer();
 
+  context('on render', () => {
+
+    it('should call a callback', () => {
+
+      // TODO : add test code here
+      throw new Error('Not implemented yet.');
+    });
+  });
+
   context('ad unit name', () => {
 
-    it('should always be "campaign-pixel"', function () {
+    it('should always be "campaign-pixel"', () => {
 
       shallowRenderer.render(<DfpPixel placement='junk' campaignId={1} />);
 
@@ -20,7 +29,7 @@ describe('<campaign-display> <DfpPixel>', () => {
 
   context('targeting parameters', () => {
 
-    it('should include ad unit placement', function () {
+    it('should include ad unit placement', () => {
       let placement = 'top';
 
       shallowRenderer.render(<DfpPixel campaignId={1} placement={ placement } />);
@@ -29,7 +38,7 @@ describe('<campaign-display> <DfpPixel>', () => {
       expect(JSON.parse(html.props['data-targeting']).dfp_placement).to.equal(placement);
     });
 
-    it('should require ad unit placement', function () {
+    it('should require ad unit placement', () => {
       chai.spy.on(console, 'error');
 
       shallowRenderer.render(<DfpPixel campaignId={1} />);
@@ -39,7 +48,7 @@ describe('<campaign-display> <DfpPixel>', () => {
       );
     });
 
-    it('should include campaign id', function () {
+    it('should include campaign id', () => {
       let id = 1;
 
       shallowRenderer.render(<DfpPixel campaignId={ id } placement='junk' />);
@@ -48,7 +57,7 @@ describe('<campaign-display> <DfpPixel>', () => {
       expect(JSON.parse(html.props['data-targeting']).dfp_campaign_id).to.equal(id);
     });
 
-    it('should require campaign id', function () {
+    it('should require campaign id', () => {
       chai.spy.on(console, 'error');
 
       shallowRenderer.render(<DfpPixel placement='junk' />);

--- a/elements/campaign-display/components/dfp-pixel.test.js
+++ b/elements/campaign-display/components/dfp-pixel.test.js
@@ -26,7 +26,7 @@ describe('<campaign-display> <DfpPixel>', () => {
       shallowRenderer.render(<DfpPixel campaignId={1} placement={ placement } />);
 
       let html = shallowRenderer.getRenderOutput();
-      expect(html.props['data-targeting'].dfp_placement).to.equal(placement);
+      expect(JSON.parse(html.props['data-targeting']).dfp_placement).to.equal(placement);
     });
 
     it('should require ad unit placement', function () {
@@ -45,7 +45,7 @@ describe('<campaign-display> <DfpPixel>', () => {
       shallowRenderer.render(<DfpPixel campaignId={ id } placement='junk' />);
 
       let html = shallowRenderer.getRenderOutput();
-      expect(html.props['data-targeting'].dfp_campaign_id).to.equal(id);
+      expect(JSON.parse(html.props['data-targeting']).dfp_campaign_id).to.equal(id);
     });
 
     it('should require campaign id', function () {

--- a/elements/campaign-display/components/dfp-pixel.test.js
+++ b/elements/campaign-display/components/dfp-pixel.test.js
@@ -1,70 +1,94 @@
-import { createRenderer } from 'react-addons-test-utils';
 import React from 'react';
+import ReactDOM from 'react-dom';
 
 import DfpPixel from './dfp-pixel';
 
 describe('<campaign-display> <DfpPixel>', () => {
 
-  let shallowRenderer = createRenderer();
+  let reactContainer;
+
+  beforeEach(() => {
+    reactContainer = document.createElement('react-container');
+    document.body.appendChild(reactContainer);
+  });
+
+  afterEach(() => {
+    reactContainer.remove();
+  });
 
   context('on render', () => {
 
     it('should call a callback', () => {
+      window.my = {
+        function: {
+          callback: chai.spy(),
+        },
+      };
 
-      // TODO : add test code here
-      throw new Error('Not implemented yet.');
-    });
-  });
-
-  context('ad unit name', () => {
-
-    it('should always be "campaign-pixel"', () => {
-
-      shallowRenderer.render(<DfpPixel placement='junk' campaignId={1} />);
-
-      let html = shallowRenderer.getRenderOutput();
-      expect(html.props['data-ad-unit']).to.equal('campaign-pixel');
-    });
-  });
-
-  context('targeting parameters', () => {
-
-    it('should include ad unit placement', () => {
-      let placement = 'top';
-
-      shallowRenderer.render(<DfpPixel campaignId={1} placement={ placement } />);
-
-      let html = shallowRenderer.getRenderOutput();
-      expect(JSON.parse(html.props['data-targeting']).dfp_placement).to.equal(placement);
-    });
-
-    it('should require ad unit placement', () => {
-      chai.spy.on(console, 'error');
-
-      shallowRenderer.render(<DfpPixel campaignId={1} />);
-
-      expect(console.error).to.have.been.called.with(
-        'Warning: Failed propType: Required prop `placement` was not specified in `DfpPixel`.'
+      let subject = ReactDOM.render(
+        <DfpPixel
+            placement='junk'
+            campaignId={1}
+            onRender='my.function.callback' />,
+        reactContainer
       );
-    });
 
-    it('should include campaign id', () => {
-      let id = 1;
-
-      shallowRenderer.render(<DfpPixel campaignId={ id } placement='junk' />);
-
-      let html = shallowRenderer.getRenderOutput();
-      expect(JSON.parse(html.props['data-targeting']).dfp_campaign_id).to.equal(id);
-    });
-
-    it('should require campaign id', () => {
-      chai.spy.on(console, 'error');
-
-      shallowRenderer.render(<DfpPixel placement='junk' />);
-
-      expect(console.error).to.have.been.called.with(
-        'Warning: Failed propType: Required prop `campaignId` was not specified in `DfpPixel`.'
-      );
+      expect(window.my.function.callback)
+        .to.have.been.called.with(subject.refs.container);
     });
   });
+
+
+// TODO : add these back
+  // context('ad unit name', () => {
+  //
+  //   it('should always be "campaign-pixel"', () => {
+  //
+  //     shallowRenderer.render(<DfpPixel placement='junk' campaignId={1} />);
+  //
+  //     let html = shallowRenderer.getRenderOutput();
+  //     expect(html.props['data-ad-unit']).to.equal('campaign-pixel');
+  //   });
+  // });
+  //
+  // context('targeting parameters', () => {
+  //
+  //   it('should include ad unit placement', () => {
+  //     let placement = 'top';
+  //
+  //     shallowRenderer.render(<DfpPixel campaignId={1} placement={ placement } />);
+  //
+  //     let html = shallowRenderer.getRenderOutput();
+  //     expect(JSON.parse(html.props['data-targeting']).dfp_placement).to.equal(placement);
+  //   });
+  //
+  //   it('should require ad unit placement', () => {
+  //     chai.spy.on(console, 'error');
+  //
+  //     shallowRenderer.render(<DfpPixel campaignId={1} />);
+  //
+  //     expect(console.error).to.have.been.called.with(
+  //       'Warning: Failed propType: Required prop `placement` was not specified in `DfpPixel`.'
+  //     );
+  //   });
+  //
+  //   it('should include campaign id', () => {
+  //     let id = 1;
+  //
+  //     shallowRenderer.render(<DfpPixel campaignId={ id } placement='junk' />);
+  //
+  //     let html = shallowRenderer.getRenderOutput();
+  //     expect(JSON.parse(html.props['data-targeting']).dfp_campaign_id).to.equal(id);
+  //   });
+  //
+  //   it('should require campaign id', () => {
+  //     chai.spy.on(console, 'error');
+  //
+  //     shallowRenderer.render(<DfpPixel placement='junk' />);
+  //
+  //     expect(console.error).to.have.been.called.with(
+  //       'Warning: Failed propType: Required prop `campaignId` was not specified in `DfpPixel`.'
+  //     );
+  //   });
+  // });
 });

--- a/elements/campaign-display/components/dfp-pixel.test.js
+++ b/elements/campaign-display/components/dfp-pixel.test.js
@@ -1,0 +1,59 @@
+import { createRenderer } from 'react-addons-test-utils';
+import React from 'react';
+
+import DfpPixel from './dfp-pixel';
+
+// TODO : looks like this:
+// <div
+//     data-ad-unit-"{{ adUnitName }}"
+//     data-targeting="{{ targetingObj }}">
+// </div>
+
+describe('<campaign-display> <DfpPixel>', () => {
+
+  let adUnitName = 'my-favorite-ad-unit';
+  let shallowRenderer = createRenderer();
+
+  context('ad unit name', () => {
+
+    it('should render that attribute in the dfp pixel div', function () {
+
+      shallowRenderer.render(<DfpPixel adUnitName={ adUnitName } />);
+
+      expect(shallowRenderer.getRenderOutput().props['data-ad-unit'])
+        .to.equal(adUnitName);
+    });
+
+    it('should be required', function () {
+
+      // TODO : add test code here
+      throw new Error('Not implemented yet.');
+    });
+  });
+
+  context('targeting parameters', () => {
+
+    it('should render that attribute in the dfp pixel div', function () {
+      let targetingParams = {
+        dfp_param_1: 'my garbage ad',
+        dfp_param_2: 'some garbage parameter',
+      };
+
+      shallowRenderer.render(
+        <DfpPixel
+          adUnitName={ adUnitName }
+          targetingParams={ targetingParams } />
+      );
+
+      expect(shallowRenderer.getRenderOutput().props['data-targeting'])
+        .to.eql(targetingParams);
+    });
+
+    it('should not render if not provided', function () {
+
+      shallowRenderer.render(<DfpPixel adUnitName={ adUnitName } />);
+
+      expect(shallowRenderer.getRenderOutput().props['data-targeting']).to.be.undefined;
+    });
+  });
+});

--- a/elements/campaign-display/components/dfp-pixel.test.js
+++ b/elements/campaign-display/components/dfp-pixel.test.js
@@ -3,15 +3,6 @@ import React from 'react';
 
 import DfpPixel from './dfp-pixel';
 
-// TODO : looks like this:
-// <div
-//     data-ad-unit="campaign-pixel"
-//     data-targeting="{
-//        dfp_placement: "{ somethingPassedIn }"    <-- passed in as attr on component
-//        dfp_campaign_id: 1                            <-- from campaign json
-//      }">
-// </div>
-
 describe('<campaign-display> <DfpPixel>', () => {
 
   let shallowRenderer = createRenderer();

--- a/elements/campaign-display/components/dfp-pixel.test.js
+++ b/elements/campaign-display/components/dfp-pixel.test.js
@@ -5,55 +5,66 @@ import DfpPixel from './dfp-pixel';
 
 // TODO : looks like this:
 // <div
-//     data-ad-unit-"{{ adUnitName }}"
-//     data-targeting="{{ targetingObj }}">
+//     data-ad-unit="campaign-pixel"
+//     data-targeting="{
+//        dfp_placement: "{ somethingPassedIn }"    <-- passed in as attr on component
+//        dfp_campaign_id: 1                            <-- from campaign json
+//      }">
 // </div>
 
 describe('<campaign-display> <DfpPixel>', () => {
 
-  let adUnitName = 'my-favorite-ad-unit';
   let shallowRenderer = createRenderer();
 
   context('ad unit name', () => {
 
-    it('should render that attribute in the dfp pixel div', function () {
+    it('should always be "campaign-pixel"', function () {
 
-      shallowRenderer.render(<DfpPixel adUnitName={ adUnitName } />);
+      shallowRenderer.render(<DfpPixel placement="junk" campaignId='1' />);
 
-      expect(shallowRenderer.getRenderOutput().props['data-ad-unit'])
-        .to.equal(adUnitName);
-    });
-
-    it('should be required', function () {
-
-      // TODO : add test code here
-      throw new Error('Not implemented yet.');
+      let html = shallowRenderer.getRenderOutput();
+      expect(html.props['data-ad-unit']).to.equal('campaign-pixel');
     });
   });
 
   context('targeting parameters', () => {
 
-    it('should render that attribute in the dfp pixel div', function () {
-      let targetingParams = {
-        dfp_param_1: 'my garbage ad',
-        dfp_param_2: 'some garbage parameter',
-      };
+    it('should include ad unit placement', function () {
+      let placement = 'top';
 
-      shallowRenderer.render(
-        <DfpPixel
-          adUnitName={ adUnitName }
-          targetingParams={ targetingParams } />
-      );
+      shallowRenderer.render(<DfpPixel campaignId='1' placement={ placement } />);
 
-      expect(shallowRenderer.getRenderOutput().props['data-targeting'])
-        .to.eql(targetingParams);
+      let html = shallowRenderer.getRenderOutput();
+      expect(html.props['data-targeting'].dfp_placement).to.equal(placement);
     });
 
-    it('should not render if not provided', function () {
+    it('should require ad unit placement', function () {
+      chai.spy.on(console, 'error');
 
-      shallowRenderer.render(<DfpPixel adUnitName={ adUnitName } />);
+      shallowRenderer.render(<DfpPixel campaignId='1' />);
 
-      expect(shallowRenderer.getRenderOutput().props['data-targeting']).to.be.undefined;
+      expect(console.error).to.have.been.called.with(
+        'Warning: Failed propType: Required prop `placement` was not specified in `DfpPixel`.'
+      );
+    });
+
+    it('should include campaign id', function () {
+      let id = 1;
+
+      shallowRenderer.render(<DfpPixel campaignId={ id } placement='junk' />);
+
+      let html = shallowRenderer.getRenderOutput();
+      expect(html.props['data-targeting'].dfp_campaign_id).to.equal(id);
+    });
+
+    it('should require campaign id', function () {
+      chai.spy.on(console, 'error');
+
+      shallowRenderer.render(<DfpPixel placement="junk" />);
+
+      expect(console.error).to.have.been.called.with(
+        'Warning: Failed propType: Required prop `campaignId` was not specified in `DfpPixel`.'
+      );
     });
   });
 });

--- a/elements/campaign-display/components/logo.js
+++ b/elements/campaign-display/components/logo.js
@@ -37,7 +37,7 @@ export default class Logo extends Component {
 }
 
 Logo.propTypes = {
-  clickthrough_url: PropTypes.string,
+  clickthrough_url: PropTypes.string.isRequired,
   crop: PropTypes.string,
   image_id: PropTypes.number.isRequired,
 };

--- a/elements/campaign-display/components/logo.js
+++ b/elements/campaign-display/components/logo.js
@@ -9,7 +9,7 @@ export default class Logo extends Component {
   componentDidMount () {
     // check if window.picturefill is available at mount time, otherwise wait
     //  until the document is loaded, and hopefully image.js is loaded, and try
-    //    window.picturefill again
+    //  window.picturefill again
     if (typeof window.picturefill === 'function') {
       doPicturefill(this);
     }

--- a/elements/campaign-display/components/logo.js
+++ b/elements/campaign-display/components/logo.js
@@ -1,15 +1,35 @@
 import React, { PropTypes } from 'react';
 
+let doPicturefill = function (component) {
+  window.picturefill(component.refs.image);
+};
+
 export default class Logo extends React.Component {
 
   componentDidMount () {
-    window.picturefill(this.refs.image);
+    // check if window.picturefill is available at mount time, otherwise wait
+    //  until the document is loaded, and hopefully image.js is loaded, and try
+    //    window.picturefill again
+    if (typeof window.picturefill === 'function') {
+      doPicturefill(this);
+    }
+    else {
+      window.addEventListener('load', doPicturefill.bind(null, this));
+    }
   }
 
   render () {
     let crop = this.props.crop || 'original';
     let hasUrl = !!this.props.clickthrough_url;
-    let image = <div ref="image" data-type="image" data-image-id={this.props.image_id} data-crop={crop}></div>;
+    let image = (
+      <div
+          ref="image"
+          data-type="image"
+          data-image-id={this.props.image_id}
+          data-crop={crop}>
+        <div></div>
+      </div>
+    );
     let link = <a ref="linkWrapper" href={this.props.clickthrough_url}>{image}</a>;
 
     return hasUrl ? link : image;

--- a/elements/campaign-display/components/logo.js
+++ b/elements/campaign-display/components/logo.js
@@ -1,11 +1,19 @@
 import React, { PropTypes } from 'react';
 
-export default function Logo (props) {
-  let crop = props.crop || 'original';
-  let hasUrl = !!props.clickthrough_url;
-  let image = <div data-type="image" data-image-id={props.image_id} data-crop={crop}></div>;
-  let link = <a href={props.clickthrough_url}>{image}</a>;
-  return hasUrl ? link : image;
+export default class Logo extends React.Component {
+
+  componentDidMount () {
+    window.picturefill(this.refs.image);
+  }
+
+  render () {
+    let crop = this.props.crop || 'original';
+    let hasUrl = !!this.props.clickthrough_url;
+    let image = <div ref="image" data-type="image" data-image-id={this.props.image_id} data-crop={crop}></div>;
+    let link = <a ref="linkWrapper" href={this.props.clickthrough_url}>{image}</a>;
+
+    return hasUrl ? link : image;
+  }
 }
 
 Logo.propTypes = {

--- a/elements/campaign-display/components/logo.js
+++ b/elements/campaign-display/components/logo.js
@@ -1,10 +1,10 @@
-import React, { PropTypes } from 'react';
+import React, { PropTypes, Component } from 'react';
 
 let doPicturefill = function (component) {
   window.picturefill(component.refs.image);
 };
 
-export default class Logo extends React.Component {
+export default class Logo extends Component {
 
   componentDidMount () {
     // check if window.picturefill is available at mount time, otherwise wait
@@ -23,16 +23,16 @@ export default class Logo extends React.Component {
     let hasUrl = !!this.props.clickthrough_url;
     let image = (
       <div
-          ref="image"
-          data-type="image"
+          ref='image'
+          data-type='image'
           data-image-id={this.props.image_id}
           data-crop={crop}>
         <div></div>
       </div>
     );
-    let link = <a ref="linkWrapper" href={this.props.clickthrough_url}>{image}</a>;
+    let link = <a ref='linkWrapper' href={this.props.clickthrough_url}>{image}</a>;
 
-    return <div className="campaign-display-logo">{ hasUrl ? link : image }</div>;
+    return <div className='campaign-display-logo'>{ hasUrl ? link : image }</div>;
   }
 }
 

--- a/elements/campaign-display/components/logo.js
+++ b/elements/campaign-display/components/logo.js
@@ -32,7 +32,7 @@ export default class Logo extends React.Component {
     );
     let link = <a ref="linkWrapper" href={this.props.clickthrough_url}>{image}</a>;
 
-    return hasUrl ? link : image;
+    return <div className="campaign-display-logo">{ hasUrl ? link : image }</div>;
   }
 }
 

--- a/elements/campaign-display/components/logo.test.js
+++ b/elements/campaign-display/components/logo.test.js
@@ -1,12 +1,38 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 import { createRenderer } from 'react-addons-test-utils';
 import Logo from './logo';
 
 describe('<campaign-display> <Logo>', () => {
   let clickthroughUrl = 'http://example.com';
+  let reactContainer;
   let props;
   let shallowRenderer = createRenderer();
   let subject;
+
+  beforeEach(() => {
+    reactContainer = document.createElement('react-container');
+    document.body.appendChild(reactContainer);
+  });
+
+  afterEach(() => {
+    reactContainer.remove();
+  })
+
+  context('picturefill', () => {
+
+    it('should be called during render', () => {
+      props = {
+        name: 'Test Campaign',
+        image_id: 1,
+      };
+      window.picturefill = chai.spy(() => {});
+
+      subject = ReactDOM.render(<Logo {...props} />, reactContainer);
+
+      expect(window.picturefill).to.have.been.called.with(subject.refs.image);
+    });
+  });
 
   context('without a clickthrough_url', () => {
     beforeEach(() => {
@@ -14,21 +40,24 @@ describe('<campaign-display> <Logo>', () => {
         name: 'Test Campaign',
         image_id: 1,
       };
-      shallowRenderer.render(<Logo {...props} />);
-      subject = shallowRenderer.getRenderOutput();
+      subject = ReactDOM.render(<Logo {...props} />, reactContainer);
     });
 
     it('renders the image container with the required attributes', () => {
-      expect(subject.props['data-type']).to.equal('image');
-      expect(subject.props['data-image-id']).to.equal(1);
-      expect(subject.props['data-crop']).to.equal('original');
+      let element = subject.refs.image;
+
+      expect(element.getAttribute('data-type')).to.equal('image');
+      expect(element.getAttribute('data-image-id')).to.equal('1');
+      expect(element.getAttribute('data-crop')).to.equal('original');
     });
 
     it('allows the crop value to be configured', () => {
       props.crop = 'custom-crop';
-      shallowRenderer.render(<Logo {...props} />);
-      subject = shallowRenderer.getRenderOutput();
-      expect(subject.props['data-crop']).to.equal('custom-crop');
+
+      subject = ReactDOM.render(<Logo {...props} />, reactContainer);
+
+      let element = subject.refs.image;
+      expect(element.getAttribute('data-crop')).to.equal('custom-crop');
     });
   });
 
@@ -39,12 +68,14 @@ describe('<campaign-display> <Logo>', () => {
         image_id: 1,
         clickthrough_url: clickthroughUrl,
       };
-      shallowRenderer.render(<Logo {...props} />);
-      subject = shallowRenderer.getRenderOutput();
+      subject = ReactDOM.render(<Logo {...props} />, reactContainer);
     });
 
     it('wraps the image in a link to the clickthrough_url', () => {
-      expect(subject.type).to.equal('a');
+
+      let element = subject.refs.linkWrapper;
+      expect(element.tagName).to.equal('A');
+      expect(element.getAttribute('href')).to.equal(props.clickthrough_url);
     });
   });
 });

--- a/elements/campaign-display/components/logo.test.js
+++ b/elements/campaign-display/components/logo.test.js
@@ -43,12 +43,18 @@ describe('<campaign-display> <Logo>', () => {
       subject = ReactDOM.render(<Logo {...props} />, reactContainer);
     });
 
-    it('renders the image container with the required attributes', () => {
+    it('should render the image container with the required attributes', () => {
       let element = subject.refs.image;
 
       expect(element.getAttribute('data-type')).to.equal('image');
       expect(element.getAttribute('data-image-id')).to.equal('1');
       expect(element.getAttribute('data-crop')).to.equal('original');
+    });
+
+    it('should render the image container with a child div', function () {
+      // NOTE : this is required for compatibility with our image.js code :(
+
+      expect(subject.refs.image.children[0].tagName).to.equal('DIV');
     });
 
     it('allows the crop value to be configured', () => {

--- a/elements/campaign-display/components/logo.test.js
+++ b/elements/campaign-display/components/logo.test.js
@@ -1,13 +1,11 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { createRenderer } from 'react-addons-test-utils';
 import Logo from './logo';
 
 describe('<campaign-display> <Logo>', () => {
   let clickthroughUrl = 'http://example.com';
   let reactContainer;
   let props;
-  let shallowRenderer = createRenderer();
   let subject;
 
   beforeEach(() => {
@@ -17,7 +15,7 @@ describe('<campaign-display> <Logo>', () => {
 
   afterEach(() => {
     reactContainer.remove();
-  })
+  });
 
   context('picturefill', () => {
 

--- a/elements/campaign-display/components/preamble.js
+++ b/elements/campaign-display/components/preamble.js
@@ -1,7 +1,7 @@
 import React, { PropTypes } from 'react';
 
 export default function Preamble(props) {
-  return (<span className="campaign-display-preamble">{props.text}</span>);
+  return <span className='campaign-display-preamble'>{props.text}</span>;
 }
 
 Preamble.propTypes = {

--- a/elements/campaign-display/components/preamble.js
+++ b/elements/campaign-display/components/preamble.js
@@ -1,7 +1,7 @@
 import React, { PropTypes } from 'react';
 
 export default function Preamble(props) {
-  return (<span>{props.text}</span>);
+  return (<span className="campaign-display-preamble">{props.text}</span>);
 }
 
 Preamble.propTypes = {

--- a/elements/campaign-display/components/sponsor-name.js
+++ b/elements/campaign-display/components/sponsor-name.js
@@ -6,7 +6,7 @@ export default class SponsorName extends Component {
     let hasUrl = !!this.props.clickthrough_url;
     let name = <span ref='name'>{this.props.name}</span>;
     let link = <a ref='linkWrapper' href={this.props.clickthrough_url}>{name}</a>;
-    return <div className='campaign-display-sponsor-name'>{hasUrl ? link : name}</div>;
+    return <span className='campaign-display-sponsor-name'>{hasUrl ? link : name}</span>;
   }
 }
 

--- a/elements/campaign-display/components/sponsor-name.js
+++ b/elements/campaign-display/components/sponsor-name.js
@@ -2,7 +2,7 @@ import React, { PropTypes } from 'react';
 
 export default function SponsorName (props) {
   let hasUrl = !!props.clickthrough_url;
-  let name = <span className='campaign-display-name'>{props.name}</span>;
+  let name = <span className='campaign-display-sponsor-name'>{props.name}</span>;
   let link = <a href={props.clickthrough_url}>{name}</a>;
   return hasUrl ? link : name;
 }

--- a/elements/campaign-display/components/sponsor-name.js
+++ b/elements/campaign-display/components/sponsor-name.js
@@ -1,12 +1,16 @@
-import React, { PropTypes } from 'react';
+import React, { PropTypes, Component } from 'react';
 
-export default function SponsorName (props) {
-  let hasUrl = !!props.clickthrough_url;
-  let name = <span className='campaign-display-sponsor-name'>{props.name}</span>;
-  let link = <a href={props.clickthrough_url}>{name}</a>;
-  return hasUrl ? link : name;
+export default class SponsorName extends Component {
+
+  render () {
+    let hasUrl = !!this.props.clickthrough_url;
+    let name = <span ref='name'>{this.props.name}</span>;
+    let link = <a ref='linkWrapper' href={this.props.clickthrough_url}>{name}</a>;
+    return <div className='campaign-display-sponsor-name'>{hasUrl ? link : name}</div>;
+  }
 }
 
 SponsorName.propTypes = {
+  clickthrough_url: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
 };

--- a/elements/campaign-display/components/sponsor-name.test.js
+++ b/elements/campaign-display/components/sponsor-name.test.js
@@ -1,36 +1,45 @@
 import React from 'react';
-import { createRenderer } from 'react-addons-test-utils';
+import ReactDOM from 'react-dom';
 import SponsorName from './sponsor-name';
 
 describe('<campaign-display> <CampaignDisplayName>', () => {
-  let shallowRenderer = createRenderer();
+  let reactContainer;
   let sponsorName = 'Test Campaign';
   let subject;
 
+  beforeEach(() => {
+    reactContainer = document.createElement('react-container');
+    document.body.appendChild(reactContainer);
+  });
+
+  afterEach(() => {
+    reactContainer.remove();
+  });
+
   context('without a clickthrough_url', () => {
     beforeEach(() => {
-      shallowRenderer.render(<SponsorName name={sponsorName} />);
-      subject = shallowRenderer.getRenderOutput();
+      subject = ReactDOM.render(<SponsorName name={sponsorName} />, reactContainer);
     });
 
     it('renders the campaign name', () => {
-      expect(subject.props.children).to.equal('Test Campaign');
+      expect(subject.refs.name.innerHTML).to.equal('Test Campaign');
     });
   });
 
   context('with a clickthrough_url', () => {
     let props;
+
     beforeEach(() => {
       props = {
         name: sponsorName,
         clickthrough_url: 'http://example.com',
       };
-      shallowRenderer.render(<SponsorName {...props} />);
-      subject = shallowRenderer.getRenderOutput();
+      subject = ReactDOM.render(<SponsorName {...props} />, reactContainer);
     });
 
     it('wraps the image in a link to the clickthrough_url', () => {
-      expect(subject.type).to.equal('a');
+      expect(subject.refs.linkWrapper.getAttribute('href'))
+        .to.equal(props.clickthrough_url);
     });
   });
 });

--- a/examples/index.js
+++ b/examples/index.js
@@ -1,4 +1,5 @@
-/*eslint react/no-unknown-property: "off"*/
+/* eslint-disable react/no-unknown-property */
+
 import React from 'react';
 import { Link } from 'react-router';
 import examples from './element-examples';
@@ -17,25 +18,29 @@ export default class Index extends React.Component {
           <ul>
             {
               examples.map((group, index) => {
-                return <li key={index} className="examples-example-group">
-                  <code>
-                    {`<${group.element}>`}
-                  </code>
-                  <ul>
-                    {
-                      Object.keys(group.examples).map((name) => {
-                        return <li key={name} className="examples-example">
-                          <Link
-                            to={`/example/${group.element}/${inflection.dasherize(name)}`}
-                            activeClassName="active"
-                          >
-                            {group.examples[name].title}
-                          </Link>
-                        </li>
-                      })
-                    }
-                  </ul>
-                </li>
+                return (
+                  <li key={index} className="examples-example-group">
+                    <code>
+                      {`<${group.element}>`}
+                    </code>
+                    <ul>
+                      {
+                        Object.keys(group.examples).map((name) => {
+                          return (
+                            <li key={name} className="examples-example">
+                              <Link
+                                to={`/example/${group.element}/${inflection.dasherize(name)}`}
+                                activeClassName="active"
+                              >
+                                {group.examples[name].title}
+                              </Link>
+                            </li>
+                          );
+                        })
+                      }
+                    </ul>
+                  </li>
+                );
               })
             }
           </ul>
@@ -47,4 +52,3 @@ export default class Index extends React.Component {
     );
   }
 }
-

--- a/lib/bulbs-elements/util/index.js
+++ b/lib/bulbs-elements/util/index.js
@@ -3,5 +3,5 @@ import iterateObject from './iterate-object';
 
 module.exports = {
   makeRequest,
-  iterateObject
+  iterateObject,
 };


### PR DESCRIPTION
Provides a `componentDidMount` hook for external libraries that need to interact with `<DfpPixel>` components when they're done rendering.

We'd bubble this attribute up to `<campaign-display>` elements in the form of an `on-dpf-pixel-render` attribute.