### PR TITLE
<campaign-display> <DfpPixel> with render event emitted

### DIFF
--- a/elements/campaign-display/components/dfp-pixel.js
+++ b/elements/campaign-display/components/dfp-pixel.js
@@ -1,17 +1,27 @@
-import React, { PropTypes } from 'react';
+import React, { Component, PropTypes } from 'react';
 
-export default function DfpPixel (props) {
-  let targeting = {
-    dfp_placement: props.placement,
-    dfp_campaign_id: props.campaignId,
-  };
+export default class DfpPixel extends Component {
 
-  return (
-    <div
-        data-ad-unit="campaign-pixel"
-        data-targeting={ JSON.stringify(targeting) }>
-    </div>
-  );
+  componentDidMount () {
+    let onRender = document.createEvent('Event');
+    onRender.initEvent('campaign-display-dfp-pixel-ready', true, true);
+    this.refs.container.dispatchEvent(onRender);
+  }
+
+  render () {
+    let targeting = {
+      dfp_placement: this.props.placement,
+      dfp_campaign_id: this.props.campaignId,
+    };
+
+    return (
+      <div
+          ref="container"
+          data-ad-unit="campaign-pixel"
+          data-targeting={ JSON.stringify(targeting) }>
+      </div>
+    );
+  }
 }
 
 DfpPixel.propTypes = {

--- a/elements/campaign-display/components/dfp-pixel.test.js
+++ b/elements/campaign-display/components/dfp-pixel.test.js
@@ -7,9 +7,18 @@ describe('<campaign-display> <DfpPixel>', () => {
 
   let shallowRenderer = createRenderer();
 
+  context('on render', () => {
+
+    it('should call a callback', () => {
+
+      // TODO : add test code here
+      throw new Error('Not implemented yet.');
+    });
+  });
+
   context('ad unit name', () => {
 
-    it('should always be "campaign-pixel"', function () {
+    it('should always be "campaign-pixel"', () => {
 
       shallowRenderer.render(<DfpPixel placement='junk' campaignId={1} />);
 
@@ -20,7 +29,7 @@ describe('<campaign-display> <DfpPixel>', () => {
 
   context('targeting parameters', () => {
 
-    it('should include ad unit placement', function () {
+    it('should include ad unit placement', () => {
       let placement = 'top';
 
       shallowRenderer.render(<DfpPixel campaignId={1} placement={ placement } />);
@@ -29,7 +38,7 @@ describe('<campaign-display> <DfpPixel>', () => {
       expect(JSON.parse(html.props['data-targeting']).dfp_placement).to.equal(placement);
     });
 
-    it('should require ad unit placement', function () {
+    it('should require ad unit placement', () => {
       chai.spy.on(console, 'error');
 
       shallowRenderer.render(<DfpPixel campaignId={1} />);
@@ -39,7 +48,7 @@ describe('<campaign-display> <DfpPixel>', () => {
       );
     });
 
-    it('should include campaign id', function () {
+    it('should include campaign id', () => {
       let id = 1;
 
       shallowRenderer.render(<DfpPixel campaignId={ id } placement='junk' />);
@@ -48,7 +57,7 @@ describe('<campaign-display> <DfpPixel>', () => {
       expect(JSON.parse(html.props['data-targeting']).dfp_campaign_id).to.equal(id);
     });
 
-    it('should require campaign id', function () {
+    it('should require campaign id', () => {
       chai.spy.on(console, 'error');
 
       shallowRenderer.render(<DfpPixel placement='junk' />);

--- a/elements/campaign-display/components/dfp-pixel.test.js
+++ b/elements/campaign-display/components/dfp-pixel.test.js
@@ -1,70 +1,96 @@
-import { createRenderer } from 'react-addons-test-utils';
 import React from 'react';
+import ReactDOM from 'react-dom';
 
 import DfpPixel from './dfp-pixel';
 
 describe('<campaign-display> <DfpPixel>', () => {
 
-  let shallowRenderer = createRenderer();
+  let reactContainer;
+
+  beforeEach(() => {
+    reactContainer = document.createElement('react-container');
+    document.body.appendChild(reactContainer);
+  });
+
+  afterEach(() => {
+    reactContainer.remove();
+  });
 
   context('on render', () => {
 
     it('should call a callback', () => {
-
-      // TODO : add test code here
-      throw new Error('Not implemented yet.');
-    });
-  });
-
-  context('ad unit name', () => {
-
-    it('should always be "campaign-pixel"', () => {
-
-      shallowRenderer.render(<DfpPixel placement='junk' campaignId={1} />);
-
-      let html = shallowRenderer.getRenderOutput();
-      expect(html.props['data-ad-unit']).to.equal('campaign-pixel');
-    });
-  });
-
-  context('targeting parameters', () => {
-
-    it('should include ad unit placement', () => {
-      let placement = 'top';
-
-      shallowRenderer.render(<DfpPixel campaignId={1} placement={ placement } />);
-
-      let html = shallowRenderer.getRenderOutput();
-      expect(JSON.parse(html.props['data-targeting']).dfp_placement).to.equal(placement);
-    });
-
-    it('should require ad unit placement', () => {
-      chai.spy.on(console, 'error');
-
-      shallowRenderer.render(<DfpPixel campaignId={1} />);
-
-      expect(console.error).to.have.been.called.with(
-        'Warning: Failed propType: Required prop `placement` was not specified in `DfpPixel`.'
+      let eventName = 'campaign-display-dfp-pixel-ready';
+      let elem;
+      let listener = document.addEventListener(
+        eventName,
+        (e) => {
+          elem = e.target;
+        }
       );
-    });
 
-    it('should include campaign id', () => {
-      let id = 1;
-
-      shallowRenderer.render(<DfpPixel campaignId={ id } placement='junk' />);
-
-      let html = shallowRenderer.getRenderOutput();
-      expect(JSON.parse(html.props['data-targeting']).dfp_campaign_id).to.equal(id);
-    });
-
-    it('should require campaign id', () => {
-      chai.spy.on(console, 'error');
-
-      shallowRenderer.render(<DfpPixel placement='junk' />);
-
-      expect(console.error).to.have.been.called.with(
-        'Warning: Failed propType: Required prop `campaignId` was not specified in `DfpPixel`.'
+      let subject = ReactDOM.render(
+        <DfpPixel
+            placement='junk'
+            campaignId={1} />,
+        reactContainer
       );
+
+      document.removeEventListener(eventName, listener);
+
+      expect(elem).to.eql(subject.refs.container);
     });
   });
+
+// TODO : add these back
+  // context('ad unit name', () => {
+  //
+  //   it('should always be "campaign-pixel"', () => {
+  //
+  //     shallowRenderer.render(<DfpPixel placement='junk' campaignId={1} />);
+  //
+  //     let html = shallowRenderer.getRenderOutput();
+  //     expect(html.props['data-ad-unit']).to.equal('campaign-pixel');
+  //   });
+  // });
+  //
+  // context('targeting parameters', () => {
+  //
+  //   it('should include ad unit placement', () => {
+  //     let placement = 'top';
+  //
+  //     shallowRenderer.render(<DfpPixel campaignId={1} placement={ placement } />);
+  //
+  //     let html = shallowRenderer.getRenderOutput();
+  //     expect(JSON.parse(html.props['data-targeting']).dfp_placement).to.equal(placement);
+  //   });
+  //
+  //   it('should require ad unit placement', () => {
+  //     chai.spy.on(console, 'error');
+  //
+  //     shallowRenderer.render(<DfpPixel campaignId={1} />);
+  //
+  //     expect(console.error).to.have.been.called.with(
+  //       'Warning: Failed propType: Required prop `placement` was not specified in `DfpPixel`.'
+  //     );
+  //   });
+  //
+  //   it('should include campaign id', () => {
+  //     let id = 1;
+  //
+  //     shallowRenderer.render(<DfpPixel campaignId={ id } placement='junk' />);
+  //
+  //     let html = shallowRenderer.getRenderOutput();
+  //     expect(JSON.parse(html.props['data-targeting']).dfp_campaign_id).to.equal(id);
+  //   });
+  //
+  //   it('should require campaign id', () => {
+  //     chai.spy.on(console, 'error');
+  //
+  //     shallowRenderer.render(<DfpPixel placement='junk' />);
+  //
+  //     expect(console.error).to.have.been.called.with(
+  //       'Warning: Failed propType: Required prop `campaignId` was not specified in `DfpPixel`.'
+  //     );
+  //   });
+  // });
 });


### PR DESCRIPTION
Provides a `componentDidMount` hook for external libraries that need to interact with `<DfpPixel>` components when they're done rendering.

This hook is provided as an event emitted as `'campaign-display-dfp-pixel-ready'`.