### PR TITLE
DfpPixel add dfp class and change ad manager call

### DIFF
--- a/elements/campaign-display/components/dfp-pixel.js
+++ b/elements/campaign-display/components/dfp-pixel.js
@@ -26,6 +26,7 @@ export default class DfpPixel extends Component {
     return (
       <div
           ref="container"
+          className="dfp"
           data-ad-unit="campaign-pixel"
           data-targeting={ JSON.stringify(targeting) }>
       </div>

--- a/elements/campaign-display/components/dfp-pixel.js
+++ b/elements/campaign-display/components/dfp-pixel.js
@@ -5,8 +5,8 @@ export default class DfpPixel extends Component {
   componentDidMount () {
     const adsManager = window.BULBS_ELEMENTS_ADS_MANAGER;
     if (typeof adsManager !== 'undefined' &&
-        typeof adsManager.reloadAds === 'function') {
-      adsManager.reloadAds(this.refs.container);
+        typeof adsManager.loadAds === 'function') {
+      adsManager.loadAds(this.refs.container);
     }
     else {
       console.warn(

--- a/elements/campaign-display/components/dfp-pixel.test.js
+++ b/elements/campaign-display/components/dfp-pixel.test.js
@@ -44,15 +44,15 @@ describe('<campaign-display> <DfpPixel>', () => {
       expect(subject.refs.container.className).to.contain('dfp');
     });
 
-    it('should call AdsManager.reloadAds', () => {
-      let reloadAds = chai.spy();
-      window.BULBS_ELEMENTS_ADS_MANAGER = { reloadAds };
+    it('should call AdsManager.loadAds', () => {
+      let loadAds = chai.spy();
+      window.BULBS_ELEMENTS_ADS_MANAGER = { loadAds };
 
       let subject = renderSubject();
 
       delete window.BULBS_ELEMENTS_ADS_MANAGER;
 
-      expect(reloadAds).to.have.been.called.with(subject.refs.container);
+      expect(loadAds).to.have.been.called.with(subject.refs.container);
     });
 
     it('should error out if AdsManager is not available', function () {
@@ -66,7 +66,7 @@ describe('<campaign-display> <DfpPixel>', () => {
       );
     });
 
-    it('should error out of AdsManager.reloadAds is not available', function () {
+    it('should error out of AdsManager.loadAds is not available', function () {
       window.BULBS_ELEMENTS_ADS_MANAGER = {};
 
       renderSubject();

--- a/elements/campaign-display/components/dfp-pixel.test.js
+++ b/elements/campaign-display/components/dfp-pixel.test.js
@@ -37,6 +37,13 @@ describe('<campaign-display> <DfpPixel>', () => {
 
   context('on render', () => {
 
+    it('should render an element with the class "dfp"', function () {
+
+      let subject = renderSubject();
+
+      expect(subject.refs.container.className).to.contain('dfp');
+    });
+
     it('should call AdsManager.reloadAds', () => {
       let reloadAds = chai.spy();
       window.BULBS_ELEMENTS_ADS_MANAGER = { reloadAds };
@@ -90,7 +97,8 @@ describe('<campaign-display> <DfpPixel>', () => {
 
     it('should require ad unit placement', () => {
       chai.spy.on(console, 'error');
-      let subject = renderSubject({ placement: window.undefined });
+
+      renderSubject({ placement: window.undefined });
 
       expect(console.error).to.have.been.called.with(
         'Warning: Failed propType: Required prop `placement` was not specified in `DfpPixel`.'

--- a/scripts/test-js
+++ b/scripts/test-js
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Summary: Run javascript tests.
+#
+# Relies on your package.json having a "test" script that does a single run of
+#   your tests and a "karma" script that does a continuous run of your tests.
+
+if [ "$1" = "--single-run" ] || [ "$1" = "-s" ]; then
+  npm test
+else
+  npm run karma
+fi


### PR DESCRIPTION
- [x] Add `dfp` class to `DfpPixel` `container` ref so ad manager can properly pick it up
- [x] Call `loadAds` instead of `reloadAds` on mounting `DfpPixel`