### PR TITLE
No init state for campaign field

### DIFF
--- a/elements/campaign-display/fields/campaign-field.js
+++ b/elements/campaign-display/fields/campaign-field.js
@@ -1,8 +1,4 @@
 const CampaignField = {
-  initialState: {
-    name: '',
-  },
-
   actions: {
     handleFetchComplete(state, response) {
       return response;

--- a/elements/campaign-display/fields/campaign-field.test.js
+++ b/elements/campaign-display/fields/campaign-field.test.js
@@ -11,8 +11,9 @@ describe('<campaign-display> CampaignField', () => {
   });
 
   describe('initialState', () => {
-    it('is an object', () => {
-      expect(subject.initialState).to.eql({ name: '' });
+
+    it('is undefined', () => {
+      expect(subject.initialState).to.be.undefined;
     });
   });
 


### PR DESCRIPTION
Having an initial state with a blank name is causing some problems with rendering `DfpPixel`.