### PR TITLE
Fallback to sponsor name if logo is missing

### DIFF
--- a/elements/campaign-display/components/campaign-display-root.js
+++ b/elements/campaign-display/components/campaign-display-root.js
@@ -34,7 +34,12 @@ class CampaignDisplayRoot extends Component {
   }
 
   logoComponent() {
-    return this.hasImageId() ? <Logo {...this.props.campaign} crop={this.props.logoCrop} /> : '';
+    if (this.hasImageId()) {
+      return <Logo {...this.props.campaign} crop={this.props.logoCrop} />;
+    }
+    else {
+      return this.sponsorNameComponent();
+    }
   }
 
   sponsorNameComponent() {

--- a/elements/campaign-display/components/campaign-display-root.test.js
+++ b/elements/campaign-display/components/campaign-display-root.test.js
@@ -108,10 +108,10 @@ describe('<campaign-display> <CampaignDisplayRoot>', () => {
     });
 
     context('when the campaign has no image_id', () => {
-      it('returns an empty string', () => {
+      it('returns a SponsorName component', () => {
         delete props.campaign.image_id;
         subject = new CampaignDisplayRoot(props);
-        expect(subject.logoComponent()).to.equal('');
+        expect(subject.logoComponent().type).to.equal(SponsorName);
       });
     });
   });
@@ -246,6 +246,7 @@ describe('<campaign-display> <CampaignDisplayRoot>', () => {
         id: 123,
         clickthrough_url: 'http://example.com/campaign',
         image_id: 1,
+        name: 'Test Campaign',
       };
       props = {
         campaign,
@@ -282,6 +283,11 @@ describe('<campaign-display> <CampaignDisplayRoot>', () => {
       it('does not render the logo', () => {
         let types = subject.props.children.map((c) => c.type);
         expect(types).to.not.contain(Logo);
+      });
+
+      it('renders the sponsor name', () => {
+        let types = subject.props.children.map((c) => c.type);
+        expect(types).to.contain(SponsorName);
       });
     });
 

--- a/elements/campaign-display/components/campaign-display-root.test.js
+++ b/elements/campaign-display/components/campaign-display-root.test.js
@@ -306,11 +306,8 @@ describe('<campaign-display> <CampaignDisplayRoot>', () => {
         id: 123,
         clickthrough_url: 'http://example.com/campaign',
         image_id: 1,
-<<<<<<< HEAD
         name: 'Test Campaign',
-=======
         active: true,
->>>>>>> master
       };
       props = {
         campaign,


### PR DESCRIPTION
Instead of rendering an empty string, we are now falling back to the SponsorName component
@kand @collin 