### PR TITLE
Add noLink attribute to avoid double link wrapping

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -188,7 +188,7 @@
     "one-var": [1, "never"],
     "operator-assignment": [0, "never"],
     "padded-blocks": [0, "never"],
-    "quote-props": [0, "as-needed"],
+    "quote-props": [0, "avoidEscape"],
     "quotes": [1, "single"],
     "semi-spacing": [1, { "before": false, "after": true }],
     "semi": [1, "always"],

--- a/elements/campaign-display/campaign-display.test.js
+++ b/elements/campaign-display/campaign-display.test.js
@@ -10,6 +10,7 @@ describe('<campaign-display>', () => {
   let shallowRenderer;
   let src;
   let crop;
+  let campaign;
   beforeEach(() => {
     // TODO: Prevent setState warnings spamming the console
     // We sould investigate if this is an issue with lib/bulbs-elements/store/store.js:60
@@ -18,16 +19,23 @@ describe('<campaign-display>', () => {
     crop = '16x9';
     placement = 'top';
     src = 'http://example.com';
-    props = {
-      src,
+    campaign = {
+      active: true,
       clickthrough_url: 'http://example.com/clickthrough',
-      image_id: 'http://example.com/image.jpg',
+      image_id: 1234,
       name: 'Test Campaign',
+    }
+
+    props = {
+      logoCrop: crop,
+      noLink: '',
       placement,
+      src,
     };
-    fetchMock.mock(src, props);
+
+    fetchMock.mock(src, campaign);
     shallowRenderer = createRenderer();
-    shallowRenderer.render(<CampaignDisplay src={src} placement={placement} logoCrop={crop} />);
+    shallowRenderer.render(<CampaignDisplay {...props} />);
   });
 
   it('should require a src', () => {
@@ -45,6 +53,11 @@ describe('<campaign-display>', () => {
   it('accepts a logo-crop attribute', () => {
     subject = shallowRenderer.getRenderOutput();
     expect(subject.props.logoCrop).to.equal(crop);
+  });
+
+  it('accepts a no-link attribute', () => {
+    subject = shallowRenderer.getRenderOutput();
+    expect(subject.props.noLink).to.equal('');
   });
 
   describe('initialDispatch', () => {

--- a/elements/campaign-display/components/campaign-display-root.js
+++ b/elements/campaign-display/components/campaign-display-root.js
@@ -31,7 +31,7 @@ class CampaignDisplayRoot extends Component {
 
   logoComponent() {
     if (this.hasImageId()) {
-      return <Logo {...this.props.campaign} crop={this.props.logoCrop} />;
+      return <Logo {...this.props.campaign} noLink={this.props.noLink} crop={this.props.logoCrop} />;
     }
     else {
       return this.sponsorNameComponent();
@@ -39,7 +39,7 @@ class CampaignDisplayRoot extends Component {
   }
 
   sponsorNameComponent() {
-    return this.hasSponsorName() ? <SponsorName {...this.props.campaign} /> : '';
+    return this.hasSponsorName() ? <SponsorName {...this.props.campaign} noLink={this.props.noLink} /> : '';
   }
 
   preambleTextComponent() {

--- a/elements/campaign-display/components/campaign-display-root.test.js
+++ b/elements/campaign-display/components/campaign-display-root.test.js
@@ -200,6 +200,14 @@ describe('<campaign-display> <CampaignDisplayRoot>', () => {
         expect(subject.logoComponent().type).to.equal(SponsorName);
       });
     });
+
+    context('when noLink attribute is present', () => {
+      it('passes the noLink attribute through to the component', () => {
+        props.noLink = '';
+        subject = new CampaignDisplayRoot(props);
+        expect(subject.logoComponent().props.noLink).to.equal('');
+      });
+    });
   });
 
   describe('sponsorNameComponent', () => {
@@ -215,6 +223,14 @@ describe('<campaign-display> <CampaignDisplayRoot>', () => {
         delete props.campaign.name;
         subject = new CampaignDisplayRoot(props);
         expect(subject.sponsorNameComponent()).to.equal('');
+      });
+    });
+
+    context('when noLink attribute is present', () => {
+      it('passes the noLink attribute through to the component', () => {
+        props.noLink = '';
+        subject = new CampaignDisplayRoot(props);
+        expect(subject.sponsorNameComponent().props.noLink).to.equal('');
       });
     });
   });

--- a/elements/campaign-display/components/logo.js
+++ b/elements/campaign-display/components/logo.js
@@ -2,13 +2,18 @@ import React, { Component, PropTypes } from 'react';
 import CroppedImage from 'bulbs-elements/components/cropped-image';
 
 export default class Logo extends Component {
+  shouldWrapWithLink() {
+    if (typeof this.props.noLink !== 'undefined') {
+      return false;
+    }
+    return !!this.props.clickthrough_url;
+  }
 
   render() {
-    let hasUrl = !!this.props.clickthrough_url;
     let image = <CroppedImage crop={this.props.crop} imageId={this.props.image_id}/>;
     let link = <a ref='linkWrapper' href={this.props.clickthrough_url}>{image}</a>;
 
-    return <div className='campaign-display-logo'>{ hasUrl ? link : image }</div>;
+    return <div className='campaign-display-logo'>{ this.shouldWrapWithLink() ? link : image }</div>;
   }
 }
 

--- a/elements/campaign-display/components/logo.test.js
+++ b/elements/campaign-display/components/logo.test.js
@@ -14,6 +14,27 @@ describe('<campaign-display> <Logo>', () => {
     return shallowRenderer.getRenderOutput();
   }
 
+  describe('shouldWrapLink', function() {
+    beforeEach(() => {
+      props = {
+        image_id: 1,
+        name: 'Test Campaign',
+      };
+    });
+
+    it('returns false when no-link attribute is present', () => {
+      props.noLink = '';
+      subject = new Logo(props);
+      expect(subject.shouldWrapWithLink()).to.equal(false);
+    });
+
+    it('returns true when there is a clickthrough_url', () => {
+      props.clickthrough_url = 'http://example.com';
+      subject = new Logo(props);
+      expect(subject.shouldWrapWithLink()).to.equal(true);
+    });
+  });
+
   context('without a clickthrough_url', () => {
     beforeEach(() => {
       props = {

--- a/elements/campaign-display/components/sponsor-name.js
+++ b/elements/campaign-display/components/sponsor-name.js
@@ -1,12 +1,17 @@
 import React, { PropTypes, Component } from 'react';
 
 export default class SponsorName extends Component {
+  shouldWrapWithLink() {
+    if (typeof this.props.noLink !== 'undefined') {
+      return false;
+    }
+    return !!this.props.clickthrough_url;
+  }
 
   render () {
-    let hasUrl = !!this.props.clickthrough_url;
-    let name = <span ref='name'>{this.props.name}</span>;
-    let link = <a ref='linkWrapper' href={this.props.clickthrough_url}>{name}</a>;
-    return <span className='campaign-display-sponsor-name'>{hasUrl ? link : name}</span>;
+    let name = <span>{this.props.name}</span>;
+    let link = <a href={this.props.clickthrough_url}>{name}</a>;
+    return <span className='campaign-display-sponsor-name'>{ this.shouldWrapWithLink() ? link : name }</span>;
   }
 }
 

--- a/elements/campaign-display/components/sponsor-name.test.js
+++ b/elements/campaign-display/components/sponsor-name.test.js
@@ -1,45 +1,71 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
 import SponsorName from './sponsor-name';
+import { createRenderer } from 'react-addons-test-utils';
 
-describe('<campaign-display> <CampaignDisplayName>', () => {
+describe('<campaign-display> <SponsorName>', () => {
+  let clickthrough_url = 'http://example.com';
+  let props;
   let reactContainer;
+  let shallowRenderer;
   let sponsorName = 'Test Campaign';
   let subject;
 
   beforeEach(() => {
-    reactContainer = document.createElement('react-container');
-    document.body.appendChild(reactContainer);
+    shallowRenderer = createRenderer();
+    props = {
+      name: sponsorName,
+      clickthrough_url,
+    };
   });
 
-  afterEach(() => {
-    reactContainer.remove();
+  describe('shouldWrapLink', function() {
+    beforeEach(() => {
+      props = {
+        clickthrough_url,
+        name: sponsorName,
+      };
+    });
+
+    it('returns false when no-link attribute is present', () => {
+      props.noLink = '';
+      subject = new SponsorName(props);
+      expect(subject.shouldWrapWithLink()).to.equal(false);
+    });
+
+    it('returns true when there is a clickthrough_url', () => {
+      subject = new SponsorName(props);
+      expect(subject.shouldWrapWithLink()).to.equal(true);
+    });
   });
 
   context('without a clickthrough_url', () => {
     beforeEach(() => {
-      subject = ReactDOM.render(<SponsorName name={sponsorName} />, reactContainer);
+      shallowRenderer.render(<SponsorName name={props.name} />);
+      subject = shallowRenderer.getRenderOutput();
     });
 
     it('renders the campaign name', () => {
-      expect(subject.refs.name.innerHTML).to.equal('Test Campaign');
+      expect(subject.props.children.props.children).to.equal(sponsorName);
     });
   });
 
   context('with a clickthrough_url', () => {
-    let props;
-
     beforeEach(() => {
-      props = {
-        name: sponsorName,
-        clickthrough_url: 'http://example.com',
-      };
-      subject = ReactDOM.render(<SponsorName {...props} />, reactContainer);
+      shallowRenderer.render(<SponsorName {...props}/>);
+      subject = shallowRenderer.getRenderOutput();
     });
 
-    it('wraps the image in a link to the clickthrough_url', () => {
-      expect(subject.refs.linkWrapper.getAttribute('href'))
-        .to.equal(props.clickthrough_url);
+    it('wraps the name in a link to the clickthrough_url', () => {
+      expect(subject.props.children.type).to.equal('a');
+      expect(subject.props.children.props.href).to.equal(props.clickthrough_url);
+    });
+
+    context('when no-link attribute is present', () => {
+      it('does not wrap the name in a link to the clickthrough_url ', () => {
+        shallowRenderer.render(<SponsorName {...props} noLink/>)
+        subject = shallowRenderer.getRenderOutput();
+        expect(subject.props.children.type).to.equal('span');
+      });
     });
   });
 });


### PR DESCRIPTION
Added the ability to prevent the component from wrapping the components in a link to the `clickthrough_url`.

@kand @collin 