### PR TITLE
Fix double sponsor name bug

### DIFF
--- a/elements/campaign-display/campaign-display.js
+++ b/elements/campaign-display/campaign-display.js
@@ -29,6 +29,7 @@ class CampaignDisplay extends BulbsElement {
       let options = Object.assign({}, this.state, this.props, {
         nameOnly: this.props.nameOnly === '',
         logoOnly: this.props.logoOnly === '',
+        noLink: this.props.noLink === '',
       });
       return (<CampaignDisplayRoot {...options} />);
     }
@@ -44,6 +45,7 @@ Object.assign(CampaignDisplay, {
   propTypes: {
     logoOnly: PropTypes.string,
     nameOnly: PropTypes.string,
+    noLink: PropTypes.string,
     placement: PropTypes.string.isRequired,
     preambleText: PropTypes.string,
     src: PropTypes.string.isRequired,

--- a/elements/campaign-display/campaign-display.test.js
+++ b/elements/campaign-display/campaign-display.test.js
@@ -23,7 +23,7 @@ describe('<campaign-display>', () => {
       clickthrough_url: 'http://example.com/clickthrough',
       image_url: 'http://example.com/campain-img.jpg',
       name: 'Test Campaign',
-    }
+    };
 
     props = {
       noLink: '',
@@ -55,7 +55,7 @@ describe('<campaign-display>', () => {
 
   it('accepts a no-link attribute', () => {
     subject = shallowRenderer.getRenderOutput();
-    expect(subject.props.noLink).to.equal('');
+    expect(subject.props.noLink).to.equal(true);
   });
 
   describe('initialDispatch', () => {

--- a/elements/campaign-display/components/campaign-display-root.js
+++ b/elements/campaign-display/components/campaign-display-root.js
@@ -34,7 +34,7 @@ class CampaignDisplayRoot extends Component {
       return <Logo {...this.props.campaign} noLink={this.props.noLink} />;
     }
     else {
-      return this.sponsorNameComponent();
+      return this.props.logoOnly ? this.sponsorNameComponent() : '';
     }
   }
 
@@ -118,6 +118,7 @@ CampaignDisplayRoot.propTypes = {
   logoCrop: PropTypes.string,
   logoOnly: PropTypes.bool,
   nameOnly: PropTypes.bool,
+  noLink: PropTypes.string,
   placement: PropTypes.string,
   preambleText: PropTypes.string,
 };

--- a/elements/campaign-display/components/campaign-display-root.js
+++ b/elements/campaign-display/components/campaign-display-root.js
@@ -118,7 +118,7 @@ CampaignDisplayRoot.propTypes = {
   logoCrop: PropTypes.string,
   logoOnly: PropTypes.bool,
   nameOnly: PropTypes.bool,
-  noLink: PropTypes.string,
+  noLink: PropTypes.bool,
   placement: PropTypes.string,
   preambleText: PropTypes.string,
 };

--- a/elements/campaign-display/components/campaign-display-root.test.js
+++ b/elements/campaign-display/components/campaign-display-root.test.js
@@ -207,9 +207,9 @@ describe('<campaign-display> <CampaignDisplayRoot>', () => {
 
     context('when noLink attribute is present', () => {
       it('passes the noLink attribute through to the component', () => {
-        props.noLink = '';
+        props.noLink = true;
         subject = new CampaignDisplayRoot(props);
-        expect(subject.logoComponent().props.noLink).to.equal('');
+        expect(subject.logoComponent().props.noLink).to.equal(true);
       });
     });
   });
@@ -232,9 +232,9 @@ describe('<campaign-display> <CampaignDisplayRoot>', () => {
 
     context('when noLink attribute is present', () => {
       it('passes the noLink attribute through to the component', () => {
-        props.noLink = '';
+        props.noLink = true;
         subject = new CampaignDisplayRoot(props);
-        expect(subject.sponsorNameComponent().props.noLink).to.equal('');
+        expect(subject.sponsorNameComponent().props.noLink).to.equal(true);
       });
     });
   });

--- a/elements/campaign-display/components/campaign-display-root.test.js
+++ b/elements/campaign-display/components/campaign-display-root.test.js
@@ -21,7 +21,7 @@ describe('<campaign-display> <CampaignDisplayRoot>', () => {
     preambleText = 'Presented by';
     campaign = {
       id: 123,
-      image_url:'http://example.com/img.jpg',
+      image_url: 'http://example.com/img.jpg',
       clickthrough_url: 'http://example.com/campaign',
       name: 'Test Campaign',
       active: true,
@@ -187,10 +187,21 @@ describe('<campaign-display> <CampaignDisplayRoot>', () => {
     });
 
     context('when the campaign has no image_url', () => {
-      it('returns a SponsorName component', () => {
-        delete props.campaign.image_url;
-        subject = new CampaignDisplayRoot(props);
-        expect(subject.logoComponent().type).to.equal(SponsorName);
+      context('and logoOnly is true', () => {
+        it('returns a SponsorName component', () => {
+          delete props.campaign.image_url;
+          props.logoOnly = true;
+          subject = new CampaignDisplayRoot(props);
+          expect(subject.logoComponent().type).to.equal(SponsorName);
+        });
+      });
+
+      context('and logoOnly is false', () => {
+        it('returns an empty string', function() {
+          delete props.campaign.image_url;
+          subject = new CampaignDisplayRoot(props);
+          expect(subject.logoComponent()).to.equal('');
+        });
       });
     });
 

--- a/elements/campaign-display/components/logo.js
+++ b/elements/campaign-display/components/logo.js
@@ -1,5 +1,4 @@
 import React, { Component, PropTypes } from 'react';
-import CroppedImage from 'bulbs-elements/components/cropped-image';
 
 export default class Logo extends Component {
   shouldWrapWithLink() {
@@ -21,4 +20,5 @@ Logo.propTypes = {
   clickthrough_url: PropTypes.string,
   crop: PropTypes.string,
   image_url: PropTypes.string.isRequired,
+  noLink: PropTypes.bool,
 };

--- a/elements/campaign-display/components/logo.test.js
+++ b/elements/campaign-display/components/logo.test.js
@@ -17,7 +17,7 @@ describe('<campaign-display> <Logo>', () => {
 
   describe('shouldWrapLink', function() {
     it('returns false when no-link attribute is present', () => {
-      props.noLink = '';
+      props.noLink = true;
       subject = new Logo(props);
       expect(subject.shouldWrapWithLink()).to.equal(false);
     });


### PR DESCRIPTION
I noticed that if an image is missing, 2 sponsor names will display. We only want to fallback to the sponsor name if we asked for only an image and we didn't get one.

@kand @collin 