### PR TITLE
Prevent accessing properties on undefined keys

### DIFF
--- a/elements/campaign-display/components/campaign-display-root.js
+++ b/elements/campaign-display/components/campaign-display-root.js
@@ -94,6 +94,7 @@ class CampaignDisplayRoot extends Component {
   }
 
   wrapChildren(children) {
+    if (!this.isRenderable()) { return ''; }
     if (this.props.noLink) { return children; }
     return (
       <a href={this.props.campaign.clickthrough_url}>

--- a/elements/campaign-display/components/campaign-display-root.test.js
+++ b/elements/campaign-display/components/campaign-display-root.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import CampaignDisplayRoot from './campaign-display-root';
-import DfpPixel from './dfp-pixel'
+import DfpPixel from './dfp-pixel';
 import Logo from './logo';
 import Preamble from './preamble';
 import SponsorName from './sponsor-name';


### PR DESCRIPTION
I noticed after the last patch that I was getting a bunch of errors in the console because I was no longer checking for a valid campaign before attempting to use it's properties.

@kand @collin 