### PR TITLE
Bump videohub-player 1.0.1 (sharetools fix)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "bulbs-public-analytics-manager": "theonion/bulbs-public-analytics-manager#0.1.3",
-    "videohub-player": "https://github.com/theonion/videohub-player.git#1.0.0"
+    "videohub-player": "https://github.com/theonion/videohub-player.git#1.0.1"
   },
   "resolutions": {
     "jquery": "^2.2.3"


### PR DESCRIPTION
@kand @collin 
Picks up video sharetools FB fix: https://github.com/theonion/videohub-player/commit/26712cdd7178b9e10adf135a8b718fc4f673faae