### PR TITLE
Made host channel targeting a passed in parameter

### DIFF
--- a/elements/bulbs-video/components/revealed.js
+++ b/elements/bulbs-video/components/revealed.js
@@ -66,7 +66,7 @@ export default class Revealed extends React.Component {
     ga(prefixedSet, 'dimension2', targeting.target_series || 'None');
     ga(prefixedSet, 'dimension3', targeting.target_season || 'None');
     ga(prefixedSet, 'dimension4', targeting.target_video_id || 'None');
-    ga(prefixedSet, 'dimension5', targeting.target_host_channel || 'None');
+    ga(prefixedSet, 'dimension5', this.props.targetHostChannel || 'None');
     ga(prefixedSet, 'dimension6', this.props.targetSpecialCoverage || 'None');
     ga(prefixedSet, 'dimension7', true); // `has_player` from old embed
     ga(prefixedSet, 'dimension8', this.props.autoplay || 'None'); // autoplay
@@ -141,6 +141,7 @@ Revealed.propTypes = {
   autoplayNext: PropTypes.bool,
   noEndcard: PropTypes.bool,
   targetCampaignId: PropTypes.string,
+  targetHostChannel: PropTypes.string,
   targetSpecialCoverage: PropTypes.string,
   twitterHandle: PropTypes.string,
   video: PropTypes.object.isRequired,

--- a/elements/bulbs-video/components/revealed.test.js
+++ b/elements/bulbs-video/components/revealed.test.js
@@ -28,6 +28,10 @@ describe('<bulbs-video> <Revealed>', () => {
       expect(subject.targetSpecialCoverage).to.eql(PropTypes.string);
     });
 
+    it('accepts targetHostChannel string', () => {
+      expect(subject.targetHostChannel).to.eql(PropTypes.string);
+    });
+
     it('accepts twitterHandle string', () => {
       expect(subject.twitterHandle).to.eql(PropTypes.string);
     });
@@ -114,6 +118,7 @@ describe('<bulbs-video> <Revealed>', () => {
         props = {
           targetSpecialCoverage: 'sc-slug',
           targetCampaignId: 'campaign',
+          targetHostChannel: 'host_channel',
           videojs_options: {},
           twitterHandle: 'twitter',
           autoplay: true,
@@ -127,7 +132,6 @@ describe('<bulbs-video> <Revealed>', () => {
               target_series: 'series',
               target_season: 'season',
               target_video_id: 'video_id',
-              target_host_channel: 'host_channel',
             },
           }),
         };


### PR DESCRIPTION
@collin @daytonn @MelizzaP @kand ... Making this a passed in parameter instead of being based on the `global.targeting` value because it will vary based on placement.  This mirrors more closely the old functionality where the player was an iframe embed with a `?target_host_channel=special_coverage_main` query string param