### PR TITLE
Allow muted attribute for bulbs-video element

### DIFF
--- a/elements/bulbs-video/bulbs-video-examples.js
+++ b/elements/bulbs-video/bulbs-video-examples.js
@@ -26,6 +26,18 @@ let examples = {
         `;
       },
     },
+    'Muted, autoplay player': {
+      render () {
+        return `
+          <bulbs-video
+            twitter-handle="avclub"
+            src="http://localhost:8080/fixtures/bulbs-video/special-coverage.json"
+            autoplay muted
+          >
+          </bulbs-video>
+        `;
+      },
+    },
   },
 };
 

--- a/elements/bulbs-video/bulbs-video.js
+++ b/elements/bulbs-video/bulbs-video.js
@@ -67,6 +67,7 @@ export default class BulbsVideo extends BulbsElement {
         targetHostChannel={this.props.targetHostChannel}
         targetSpecialCoverage={this.props.targetSpecialCoverage}
         autoplayNext={typeof this.props.twitterHandle === 'string'}
+        muted={typeof this.props.muted === 'string'}
         noEndcard={typeof this.props.noEndcard === 'string'}
         actions={this.store.actions}
       />
@@ -84,6 +85,7 @@ Object.assign(BulbsVideo, {
   propTypes: {
     autoplay: PropTypes.string,
     autoplayNext: PropTypes.string,
+    muted: PropTypes.string,
     noEndcard: PropTypes.string,
     src: PropTypes.string.isRequired,
     targetCampaignId: PropTypes.string,

--- a/elements/bulbs-video/components/revealed.js
+++ b/elements/bulbs-video/components/revealed.js
@@ -116,6 +116,10 @@ export default class Revealed extends React.Component {
       delete playerOptions.pluginConfig.endcard;
     }
 
+    if (this.props.muted) {
+      playerOptions.mute = true;
+    }
+
     this.makeVideoPlayer(this.refs.video, playerOptions);
   }
 
@@ -153,6 +157,7 @@ export default class Revealed extends React.Component {
 Revealed.propTypes = {
   autoplay: PropTypes.bool,
   autoplayNext: PropTypes.bool,
+  muted: PropTypes.bool,
   noEndcard: PropTypes.bool,
   targetCampaignId: PropTypes.string,
   targetHostChannel: PropTypes.string,

--- a/elements/bulbs-video/components/revealed.test.js
+++ b/elements/bulbs-video/components/revealed.test.js
@@ -16,6 +16,10 @@ describe('<bulbs-video> <Revealed>', () => {
       expect(subject.autoplayNext).to.eql(PropTypes.bool);
     });
 
+    it('accepts muted boolean', () => {
+      expect(subject.muted).to.eql(PropTypes.bool);
+    });
+
     it('accepts noEndcard boolean', () => {
       expect(subject.noEndcard).to.eql(PropTypes.bool);
     });
@@ -123,6 +127,7 @@ describe('<bulbs-video> <Revealed>', () => {
           twitterHandle: 'twitter',
           autoplay: true,
           autoplayNext: true,
+          muted: true,
           video: Object.assign({}, video, {
             title: 'video_title',
             tags: ['main', 'tag'],
@@ -148,6 +153,12 @@ describe('<bulbs-video> <Revealed>', () => {
             state,
             refs: { video: videoRef },
             makeVideoPlayer: makeVideoPlayerSpy,
+          });
+        });
+
+        it('passes through the muted value', () => {
+          expect(makeVideoPlayerSpy).to.have.been.calledWithMatch(videoRef, {
+            mute: true,
           });
         });
 

--- a/elements/bulbs-video/components/root.js
+++ b/elements/bulbs-video/components/root.js
@@ -28,6 +28,7 @@ Root.propTypes = {
   actions: PropTypes.object.isRequired,
   autoplayNext: PropTypes.bool,
   controller: PropTypes.object.isRequired,
+  muted: PropTypes.bool,
   noEndcard: PropTypes.bool,
   targetCampaignId: PropTypes.string,
   targetHostChannel: PropTypes.string,


### PR DESCRIPTION
@collin @kand @daytonn @MelizzaP - if you could review, passes through `muted` attribute to the options for the video hub player used here: 

https://github.com/theonion/videohub-player/blob/master/src/player.js#L68