### PR TITLE
jw player lint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,6 @@ scripts/*
 bower_components/*
 generator-bulbs-elements
 examples/*
+elements/bulbs-video/plugins/jwplayer.js
+elements/bulbs-video/plugins/streamsense.4.1411.18.min.js
+elements/bulbs-video/plugins/streamsense.5.1.1.160316.min.js

--- a/elements/bulbs-video/components/revealed.test.js
+++ b/elements/bulbs-video/components/revealed.test.js
@@ -407,7 +407,7 @@ describe('<bulbs-video> <Revealed>', () => {
       };
     });
 
-    it('returns the vast url', function() {
+    it('returns the vast url', function () {
       let vastUrl = Revealed.prototype.vastUrl.call({
         cacheBuster: cacheBusterStub,
         vastTest: vastTestStub,

--- a/elements/bulbs-video/plugins/comscore.js
+++ b/elements/bulbs-video/plugins/comscore.js
@@ -1,7 +1,7 @@
 require('!imports?this=>window!./streamsense.5.1.1.160316.min.js');
 
 class Comscore {
-  constructor(player, comscoreId, comscoreMetadata) {
+  constructor (player, comscoreId, comscoreMetadata) {
     this.streamingTag = new global.ns_.StreamingTag({ customerC2: comscoreId });
     this.comscoreMetadata = comscoreMetadata;
 

--- a/elements/bulbs-video/plugins/comscore.test.js
+++ b/elements/bulbs-video/plugins/comscore.test.js
@@ -18,7 +18,7 @@ describe('Comscore', () => {
       comscore.adStarted();
     });
 
-    it('calls "playVideoAdvertisement" in streaming tag lib', function() {
+    it('calls "playVideoAdvertisement" in streaming tag lib', function () {
       expect(comscore.streamingTag.playVideoAdvertisement.called).to.be.true;
     });
   });
@@ -32,7 +32,7 @@ describe('Comscore', () => {
       comscore.adEnded();
     });
 
-    it('calls "stop" in streaming tag lib', function() {
+    it('calls "stop" in streaming tag lib', function () {
       expect(comscore.streamingTag.stop.called).to.be.true;
     });
   });
@@ -49,7 +49,7 @@ describe('Comscore', () => {
       comscore.contentPlayed();
     });
 
-    it('calls "playVideoContentPart" in streaming tag lib', function() {
+    it('calls "playVideoContentPart" in streaming tag lib', function () {
       expect(comscore.streamingTag.playVideoContentPart.calledWith({
         'c3': 'onionstudios',
         'c4': 'CLICKHOLE',
@@ -66,7 +66,7 @@ describe('Comscore', () => {
       comscore.contentPaused();
     });
 
-    it('calls "stop" in streaming tag lib', function() {
+    it('calls "stop" in streaming tag lib', function () {
       expect(comscore.streamingTag.stop.called).to.be.true;
     });
   });
@@ -80,7 +80,7 @@ describe('Comscore', () => {
       comscore.contentEnded();
     });
 
-    it('calls "stop" in streaming tag lib', function() {
+    it('calls "stop" in streaming tag lib', function () {
       expect(comscore.streamingTag.stop.called).to.be.true;
     });
   });

--- a/elements/bulbs-video/plugins/google-analytics.js
+++ b/elements/bulbs-video/plugins/google-analytics.js
@@ -3,7 +3,7 @@ let prefixedSend = (gaPrefix) => {
 };
 
 class GoogleAnalytics {
-  constructor(player, gaPrefix) {
+  constructor (player, gaPrefix) {
     this.player = player;
     this.gaPrefix = gaPrefix;
 
@@ -23,7 +23,7 @@ class GoogleAnalytics {
     // .on('error')
   }
 
-  onPlay() {
+  onPlay () {
     if (!this.player.playedOnce) {
       global.ga(
         prefixedSend(this.gaPrefix),
@@ -41,7 +41,7 @@ class GoogleAnalytics {
     );
   }
 
-  onPause() {
+  onPause () {
     global.ga(
       prefixedSend(this.gaPrefix), 'event',
       'Video:' + this.player.videoMeta.channel_name,
@@ -50,7 +50,7 @@ class GoogleAnalytics {
     );
   }
 
-  onFullScreen(event) {
+  onFullScreen (event) {
     global.ga(
       prefixedSend(this.gaPrefix), 'event',
       'Video:' + this.player.videoMeta.channel_name,
@@ -59,7 +59,7 @@ class GoogleAnalytics {
     );
   }
 
-  onResize(event) {
+  onResize (event) {
     global.ga(
       prefixedSend(this.gaPrefix), 'event',
       'Video:' + this.player.videoMeta.channel_name,
@@ -68,7 +68,7 @@ class GoogleAnalytics {
     );
   }
 
-  onFirstFrame(event) {
+  onFirstFrame (event) {
     global.ga(
       prefixedSend(this.gaPrefix), 'event',
       'Video:' + this.player.videoMeta.channel_name,
@@ -78,7 +78,7 @@ class GoogleAnalytics {
     );
   }
 
-  onComplete() {
+  onComplete () {
     global.ga(
       prefixedSend(this.gaPrefix),
       'event', 'Video:' + this.player.videoMeta.channel_name,
@@ -88,7 +88,7 @@ class GoogleAnalytics {
     this.player.playedOnce = false;
   }
 
-  onAdBlock() {
+  onAdBlock () {
     global.ga(
       prefixedSend(this.gaPrefix),
       'event',
@@ -98,7 +98,7 @@ class GoogleAnalytics {
     );
   }
 
-  onAdSkipped(event) {
+  onAdSkipped (event) {
     global.ga(
       prefixedSend(this.gaPrefix),
       'event',
@@ -108,7 +108,7 @@ class GoogleAnalytics {
     );
   }
 
-  onAdError(event) {
+  onAdError (event) {
     global.ga(
       prefixedSend(this.gaPrefix),
       'event',
@@ -118,7 +118,7 @@ class GoogleAnalytics {
     );
   }
 
-  onTime(event) {
+  onTime (event) {
     this.checkSecondsElapsed(3, event);
     this.checkSecondsElapsed(10, event);
     this.checkSecondsElapsed(30, event);
@@ -128,7 +128,7 @@ class GoogleAnalytics {
     this.checkPercentage(event, 95);
   }
 
-  checkPercentage(event, percent) {
+  checkPercentage (event, percent) {
     let eventAction = percent + ' percent';
 
     if (this.player.gaEvents[eventAction]) {
@@ -148,7 +148,7 @@ class GoogleAnalytics {
     }
   }
 
-  checkSecondsElapsed(seconds, event) {
+  checkSecondsElapsed (seconds, event) {
     let eventAction = seconds + ' seconds';
 
     if (this.player.gaEvents[eventAction]) {

--- a/elements/bulbs-video/plugins/google-analytics.test.js
+++ b/elements/bulbs-video/plugins/google-analytics.test.js
@@ -379,31 +379,31 @@ describe('Google Analytics', () => {
       googleAnalytics.onTime(data);
     });
 
-    it('checks if the video is past 3 seconds', function() {
+    it('checks if the video is past 3 seconds', function () {
       expect(googleAnalytics.checkSecondsElapsed.calledWith(3, data)).to.be.true;
     });
 
-    it('checks if the video is past 10 seconds', function() {
+    it('checks if the video is past 10 seconds', function () {
       expect(googleAnalytics.checkSecondsElapsed.calledWith(10, data)).to.be.true;
     });
 
-    it('checks if the video is past 30 seconds', function() {
+    it('checks if the video is past 30 seconds', function () {
       expect(googleAnalytics.checkSecondsElapsed.calledWith(30, data)).to.be.true;
     });
 
-    it('checks for 25 percent quartile', function() {
+    it('checks for 25 percent quartile', function () {
       expect(googleAnalytics.checkPercentage.calledWith(data, 25)).to.be.true;
     });
 
-    it('checks for 50 percent quartile', function() {
+    it('checks for 50 percent quartile', function () {
       expect(googleAnalytics.checkPercentage.calledWith(data, 50)).to.be.true;
     });
 
-    it('checks for 75 percent quartile', function() {
+    it('checks for 75 percent quartile', function () {
       expect(googleAnalytics.checkPercentage.calledWith(data, 75)).to.be.true;
     });
 
-    it('checks for 95 percent quartile', function() {
+    it('checks for 95 percent quartile', function () {
       expect(googleAnalytics.checkPercentage.calledWith(data, 95)).to.be.true;
     });
   });
@@ -412,7 +412,7 @@ describe('Google Analytics', () => {
     let googleAnalytics;
     let player;
 
-    context('already sent "x seconds" event', function() {
+    context('already sent "x seconds" event', function () {
       beforeEach(() => {
         global.ga = sinon.spy();
 
@@ -441,7 +441,7 @@ describe('Google Analytics', () => {
       });
     });
 
-    context('have not sent "x seconds" event, < x seconds', function() {
+    context('have not sent "x seconds" event, < x seconds', function () {
       beforeEach(() => {
         let eventStub = {
           duration: 60,
@@ -469,7 +469,7 @@ describe('Google Analytics', () => {
       });
     });
 
-    context('have not sent "x seconds" event, > x seconds', function() {
+    context('have not sent "x seconds" event, > x seconds', function () {
       beforeEach(() => {
         let eventStub = {
           duration: 60,
@@ -501,7 +501,7 @@ describe('Google Analytics', () => {
         );
       });
 
-      it('makes sure it is not sent again', function() {
+      it('makes sure it is not sent again', function () {
         expect(player.gaEvents['3 seconds']).to.be.true;
       });
     });
@@ -529,7 +529,7 @@ describe('Google Analytics', () => {
         googleAnalytics.checkPercentage({}, 25);
       });
 
-      it('does not call ga', function() {
+      it('does not call ga', function () {
         expect(global.ga.called).to.be.false;
       });
     });
@@ -597,7 +597,7 @@ describe('Google Analytics', () => {
         );
       });
 
-      it('makes sure it is not sent again', function() {
+      it('makes sure it is not sent again', function () {
         expect(player.gaEvents['25 percent']).to.be.true;
       });
     });

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "test": "karma start --single-run",
     "karma": "karma start",
-    "lint": "node_modules/.bin/eslint elements lib *.js --max-warnings=1 --cache",
+    "lint": "node_modules/.bin/eslint elements lib --max-warnings=1 --cache",
     "coverage": "karma start karma.coverage.js --single-run"
   },
   "author": "Onion Product Team <webtech@theonion.com>",


### PR DESCRIPTION
I ignored the big jwplayer/streamsense files and ran lint with `--fix` to cleanup the simple things.

Leaves us with this remaning:

```bash
monorepo/bulbs-elements/elements/bulbs-video/components/revealed.js
  154:3  warning  Expected to return a value at the end of this method  consistent-return

monorepo/bulbs-elements/elements/bulbs-video/components/revealed.test.js
  141:1   warning  Line 141 exceeds the maximum line length of 121  max-len
  144:1   warning  Line 144 exceeds the maximum line length of 121  max-len
  145:1   warning  Line 145 exceeds the maximum line length of 121  max-len
  362:42  warning  Unexpected use of undefined                      no-undefined
  369:42  warning  Unexpected use of undefined                      no-undefined
  415:1   warning  Line 415 exceeds the maximum line length of 121  max-len
  441:1   warning  Line 441 exceeds the maximum line length of 121  max-len
  443:1   warning  Line 443 exceeds the maximum line length of 121  max-len
  444:1   warning  Line 444 exceeds the maximum line length of 121  max-len

monorepo/bulbs-elements/elements/bulbs-video/plugins/google-analytics.test.js
  280:1  warning  Line 280 exceeds the maximum line length of 121  max-len

✖ 11 problems (0 errors, 11 warnings)
```