### PR TITLE
Filtering out the cachebuster param so the analytics are a bit easier to grok

### DIFF
--- a/elements/bulbs-video/components/revealed.js
+++ b/elements/bulbs-video/components/revealed.js
@@ -159,6 +159,8 @@ export default class Revealed extends React.Component {
         return vastId;
       }
     }
+
+    return false;
   }
 
   vastUrl (videoMeta) {

--- a/elements/bulbs-video/components/revealed.test.js
+++ b/elements/bulbs-video/components/revealed.test.js
@@ -357,18 +357,18 @@ describe('<bulbs-video> <Revealed>', () => {
   });
 
   describe('vastTest', () => {
-    it('returns undefined if query string empty', () => {
+    it('returns false if query string empty', () => {
       let vastId = Revealed.prototype.vastTest.call({
         parseParam: sinon.stub().returns(undefined),
       }, '');
-      expect(vastId).to.be.undefined;
+      expect(vastId).to.be.false;
     });
 
-    it('returns undefined if no xgid query string key', () => {
+    it('returns false if no xgid query string key', () => {
       let vastId = Revealed.prototype.vastTest.call({
-        parseParam: sinon.stub().returns(undefined),
+        parseParam: sinon.stub().returns(false),
       }, '?utm_source=facebook');
-      expect(vastId).to.be.undefined;
+      expect(vastId).to.be.false;
     });
 
     it('returns the vastUrl value if query string key present', () => {

--- a/elements/bulbs-video/components/revealed.test.js
+++ b/elements/bulbs-video/components/revealed.test.js
@@ -138,11 +138,11 @@ describe('<bulbs-video> <Revealed>', () => {
             player_options: {
               'poster': 'http://i.onionstatic.com/onionstudios/4974/16x9/800.jpg',
               'advertising': {
-                'tag': 'http://us-theonion.videoplaza.tv/proxy/distributor/v2?rt=vast_2.0&pf=html5&cv=h5_1.0.14.17.1&f=&t=4045%2Cclickhole%2Cmain%2Cshort_form%2Chtml5&s=main%2Fclickhole&cf=short_form&cd=96.757551&tt=p&st=0%3A0%2C3%2C4%2C10%2C20%3A1%2C91%2C100&rnd=9206206327905602',
+                'tag': 'http://us-theonion.videoplaza.tv/proxy/distributor/v2?rt=vast_2.0&pf=html5&cv=h5_1.0.14.17.1&f=&t=4045%2Cclickhole%2Cmain%2Cshort_form%2Chtml5&s=main%2Fclickhole&cf=short_form&cd=96.757551&tt=p&st=0%3A0%2C3%2C4%2C10%2C20%3A1%2C91%2C100&rnd=9206206327905602', // eslint-disable-line max-len
 
               },
-              'shareUrl': 'http://www.onionstudios.com/videos/beautiful-watch-this-woman-use-a-raw-steak-to-bang-out-the-word-equality-in-morse-code-on-the-hood-of-her-car-4053',
-              'embedCode': '<iframe name=\"embedded\" allowfullscreen webkitallowfullscreen mozallowfullscreen frameborder=\"no\" width=\"480\" height=\"270\" scrolling=\"no\" src=\"http://www.onionstudios.com/embed?id=4023\"></iframe>',
+              'shareUrl': 'http://www.onionstudios.com/videos/beautiful-watch-this-woman-use-a-raw-steak-to-bang-out-the-word-equality-in-morse-code-on-the-hood-of-her-car-4053', // eslint-disable-line max-len
+              'embedCode': '<iframe name=\"embedded\" allowfullscreen webkitallowfullscreen mozallowfullscreen frameborder=\"no\" width=\"480\" height=\"270\" scrolling=\"no\" src=\"http://www.onionstudios.com/embed?id=4023\"></iframe>', // eslint-disable-line max-len
               'comscore': {
                 'id': 6036328,
                 'metadata': {
@@ -359,7 +359,7 @@ describe('<bulbs-video> <Revealed>', () => {
   describe('vastTest', () => {
     it('returns false if query string empty', () => {
       let vastId = Revealed.prototype.vastTest.call({
-        parseParam: sinon.stub().returns(undefined),
+        parseParam: sinon.stub().returns(false),
       }, '');
       expect(vastId).to.be.false;
     });
@@ -412,7 +412,7 @@ describe('<bulbs-video> <Revealed>', () => {
         cacheBuster: cacheBusterStub,
         vastTest: vastTestStub,
       }, videoMeta);
-      expect(vastUrl).to.equal('http://us-theonion.videoplaza.tv/proxy/distributor/v2?rt=vast_2.0&tt=p&t=clickhole,main,12345,html5&s=main/clickhole&rnd=456');
+      expect(vastUrl).to.equal('http://us-theonion.videoplaza.tv/proxy/distributor/v2?rt=vast_2.0&tt=p&t=clickhole,main,12345,html5&s=main/clickhole&rnd=456'); // eslint-disable-line max-len
     });
   });
 
@@ -438,10 +438,10 @@ describe('<bulbs-video> <Revealed>', () => {
         player_options: {
           'poster': 'http://i.onionstatic.com/onionstudios/4974/16x9/800.jpg',
           'advertising': {
-            'tag': 'http://us-theonion.videoplaza.tv/proxy/distributor/v2?rt=vast_2.0&pf=html5&cv=h5_1.0.14.17.1&f=&t=4045%2Cclickhole%2Cmain%2Cshort_form%2Chtml5&s=main%2Fclickhole&cf=short_form&cd=96.757551&tt=p&st=0%3A0%2C3%2C4%2C10%2C20%3A1%2C91%2C100&rnd=9206206327905602',
+            'tag': 'http://us-theonion.videoplaza.tv/proxy/distributor/v2?rt=vast_2.0&pf=html5&cv=h5_1.0.14.17.1&f=&t=4045%2Cclickhole%2Cmain%2Cshort_form%2Chtml5&s=main%2Fclickhole&cf=short_form&cd=96.757551&tt=p&st=0%3A0%2C3%2C4%2C10%2C20%3A1%2C91%2C100&rnd=9206206327905602', // eslint-disable-line max-len
           },
-          'shareUrl': 'http://www.onionstudios.com/videos/beautiful-watch-this-woman-use-a-raw-steak-to-bang-out-the-word-equality-in-morse-code-on-the-hood-of-her-car-4053',
-          'embedCode': '<iframe name=\"embedded\" allowfullscreen webkitallowfullscreen mozallowfullscreen frameborder=\"no\" width=\"480\" height=\"270\" scrolling=\"no\" src=\"http://www.onionstudios.com/embed?id=4023\"></iframe>',
+          'shareUrl': 'http://www.onionstudios.com/videos/beautiful-watch-this-woman-use-a-raw-steak-to-bang-out-the-word-equality-in-morse-code-on-the-hood-of-her-car-4053', // eslint-disable-line max-len
+          'embedCode': '<iframe name=\"embedded\" allowfullscreen webkitallowfullscreen mozallowfullscreen frameborder=\"no\" width=\"480\" height=\"270\" scrolling=\"no\" src=\"http://www.onionstudios.com/embed?id=4023\"></iframe>', // eslint-disable-line max-len
           'comscore': {
             'id': 6036328,
             'metadata': {

--- a/elements/bulbs-video/plugins/google-analytics.js
+++ b/elements/bulbs-video/plugins/google-analytics.js
@@ -95,23 +95,32 @@ class GoogleAnalytics {
     );
   }
 
+  filterQueryString (originalString, queryStringKey) {
+    let regex = new RegExp('[\\&|\\?]' + queryStringKey + '=\\d+');
+    return originalString.replace(regex, '');
+  }
+
   onAdSkipped (event) {
+    let filteredTag = this.filterQueryString(event.tag, 'rnd');
+
     global.ga(
       prefixedSend(this.gaPrefix),
       'event',
       'Video:' + this.player.videoMeta.channel_name,
       'adskipped',
-      event.tag
+      filteredTag
     );
   }
 
   onAdError (event) {
+    let filteredTag = this.filterQueryString(event.tag, 'rnd');
+
     global.ga(
       prefixedSend(this.gaPrefix),
       'event',
       'Video:' + this.player.videoMeta.channel_name,
       'aderror: ' + event.message,
-      event.tag
+      filteredTag
     );
   }
 

--- a/elements/bulbs-video/plugins/google-analytics.test.js
+++ b/elements/bulbs-video/plugins/google-analytics.test.js
@@ -281,6 +281,39 @@ describe('Google Analytics', () => {
     });
   });
 
+  describe('filterQueryString', () => {
+    let googleAnalytics;
+
+    beforeEach(() => {
+      let player = {
+        videoMeta: {
+          channel_name: 'The Onion',
+          player_options: {
+            'shareUrl': 'http://www.theonion.com/r/4053',
+          },
+        },
+        on: sinon.spy(),
+      };
+
+      googleAnalytics = GoogleAnalytics.init(player, 'videoplayer0');
+    });
+
+    it('filters out any querystring key/value based on passed in key when first query param', () => {
+      let filtered = googleAnalytics.filterQueryString('http://us-theonion.videoplaza.tv?rnd=12345', 'rnd');
+      expect(filtered).to.equal('http://us-theonion.videoplaza.tv');
+    });
+
+    it('filters out any querystring key/value based on passed in key when sandwiched query param', () => {
+      let filtered = googleAnalytics.filterQueryString('http://us-theonion.videoplaza.tv?foo=bar&rnd=12345&tags=1', 'rnd');
+      expect(filtered).to.equal('http://us-theonion.videoplaza.tv?foo=bar&tags=1');
+    });
+
+    it('filters out any querystring key/value based on passed in key when last query param', () => {
+      let filtered = googleAnalytics.filterQueryString('http://us-theonion.videoplaza.tv?foo=bar&rnd=12345', 'rnd');
+      expect(filtered).to.equal('http://us-theonion.videoplaza.tv?foo=bar');
+    });
+  });
+
   describe('onAdSkipped', () => {
     let eventStub;
 
@@ -300,25 +333,26 @@ describe('Google Analytics', () => {
       let googleAnalytics = GoogleAnalytics.init(player, 'videoplayer0');
       eventStub = {
         tag:
-          'http://localhost:8080/fixtures/bulbs-video/html5-vast.xml',
+          'http://us-theonion.videoplaza.tv/proxy/distributor/v2?rt=vast_2.0&tt=p&t=1125,the-onion,today-now,main,html5&s=main/the-onion/today-now?rt=vast_2.0&rnd=12345',
       };
 
       googleAnalytics.onAdSkipped(eventStub);
     });
 
-    it('sends an "adskipped" event', () => {
+    it('sends an "adskipped" event filtering out rnd value', () => {
       expect(global.ga).to.have.been.calledWith(
         'videoplayer0.send',
         'event',
         'Video:The Onion',
         'adskipped',
-        'http://localhost:8080/fixtures/bulbs-video/html5-vast.xml'
+        'http://us-theonion.videoplaza.tv/proxy/distributor/v2?rt=vast_2.0&tt=p&t=1125,the-onion,today-now,main,html5&s=main/the-onion/today-now?rt=vast_2.0'
       );
     });
   });
 
   describe('onAdError', () => {
     let eventStub;
+    let googleAnalytics;
 
     beforeEach(() => {
       global.ga = sinon.spy();
@@ -333,23 +367,57 @@ describe('Google Analytics', () => {
         on: sinon.spy(),
       };
 
-      let googleAnalytics = GoogleAnalytics.init(player, 'videoplayer0');
+      googleAnalytics = GoogleAnalytics.init(player, 'videoplayer0');
+    });
+
+    it('sends an "aderror" event without making any change if no rnd value', () => {
       eventStub = {
         tag:
-          'http://localhost:8080/fixtures/bulbs-video/html5-vast.xml',
+          'http://us-theonion.videoplaza.tv/proxy/distributor/v2?rt=vast_2.0&tt=p&t=1125,the-onion,today-now,main,html5&s=main/the-onion/today-now',
         message: 'Ad Tag Empty',
       };
 
       googleAnalytics.onAdError(eventStub);
-    });
-
-    it('sends an "aderror" event', () => {
       expect(global.ga).to.have.been.calledWith(
         'videoplayer0.send',
         'event',
         'Video:The Onion',
         'aderror: Ad Tag Empty',
-        'http://localhost:8080/fixtures/bulbs-video/html5-vast.xml'
+        'http://us-theonion.videoplaza.tv/proxy/distributor/v2?rt=vast_2.0&tt=p&t=1125,the-onion,today-now,main,html5&s=main/the-onion/today-now'
+      );
+    });
+
+    it('sends an "aderror" event filtering out rnd value when at the end', () => {
+      eventStub = {
+        tag:
+          'http://us-theonion.videoplaza.tv/proxy/distributor/v2?rt=vast_2.0&tt=p&t=1125,the-onion,today-now,main,html5&s=main/the-onion/today-now&rnd=2768879373',
+        message: 'Ad Tag Empty',
+      };
+
+      googleAnalytics.onAdError(eventStub);
+      expect(global.ga).to.have.been.calledWith(
+        'videoplayer0.send',
+        'event',
+        'Video:The Onion',
+        'aderror: Ad Tag Empty',
+        'http://us-theonion.videoplaza.tv/proxy/distributor/v2?rt=vast_2.0&tt=p&t=1125,the-onion,today-now,main,html5&s=main/the-onion/today-now'
+      );
+    });
+
+    it('sends an "aderror" event filtering out rnd value when sandwiched', () => {
+      eventStub = {
+        tag:
+          'http://us-theonion.videoplaza.tv/proxy/distributor/v2?rt=vast_2.0&tt=p&t=1125,the-onion,today-now,main,html5&s=main/the-onion/today-now&rnd=2768879373&foo=bar',
+        message: 'Ad Tag Empty',
+      };
+
+      googleAnalytics.onAdError(eventStub);
+      expect(global.ga).to.have.been.calledWith(
+        'videoplayer0.send',
+        'event',
+        'Video:The Onion',
+        'aderror: Ad Tag Empty',
+        'http://us-theonion.videoplaza.tv/proxy/distributor/v2?rt=vast_2.0&tt=p&t=1125,the-onion,today-now,main,html5&s=main/the-onion/today-now&foo=bar'
       );
     });
   });

--- a/elements/bulbs-video/plugins/google-analytics.test.js
+++ b/elements/bulbs-video/plugins/google-analytics.test.js
@@ -277,7 +277,13 @@ describe('Google Analytics', () => {
     });
 
     it('sends an "adblock" event', () => {
-      expect(global.ga).to.have.been.calledWith('videoplayer0.send', 'event', 'Video:The Onion', 'adblock:enabled', 'http://www.theonion.com/r/4053');
+      expect(global.ga).to.have.been.calledWith(
+        'videoplayer0.send',
+        'event',
+        'Video:The Onion',
+        'adblock:enabled',
+        'http://www.theonion.com/r/4053'
+      );
     });
   });
 
@@ -304,7 +310,7 @@ describe('Google Analytics', () => {
     });
 
     it('filters out any querystring key/value based on passed in key when sandwiched query param', () => {
-      let filtered = googleAnalytics.filterQueryString('http://us-theonion.videoplaza.tv?foo=bar&rnd=12345&tags=1', 'rnd');
+      let filtered = googleAnalytics.filterQueryString('http://us-theonion.videoplaza.tv?foo=bar&rnd=12345&tags=1', 'rnd'); // eslint-disable-line max-len
       expect(filtered).to.equal('http://us-theonion.videoplaza.tv?foo=bar&tags=1');
     });
 
@@ -333,7 +339,7 @@ describe('Google Analytics', () => {
       let googleAnalytics = GoogleAnalytics.init(player, 'videoplayer0');
       eventStub = {
         tag:
-          'http://us-theonion.videoplaza.tv/proxy/distributor/v2?rt=vast_2.0&tt=p&t=1125,the-onion,today-now,main,html5&s=main/the-onion/today-now?rt=vast_2.0&rnd=12345',
+          'http://us-theonion.videoplaza.tv/proxy/distributor/v2?rt=vast_2.0&tt=p&t=1125,the-onion,today-now,main,html5&s=main/the-onion/today-now?rt=vast_2.0&rnd=12345', // eslint-disable-line max-len
       };
 
       googleAnalytics.onAdSkipped(eventStub);
@@ -345,7 +351,7 @@ describe('Google Analytics', () => {
         'event',
         'Video:The Onion',
         'adskipped',
-        'http://us-theonion.videoplaza.tv/proxy/distributor/v2?rt=vast_2.0&tt=p&t=1125,the-onion,today-now,main,html5&s=main/the-onion/today-now?rt=vast_2.0'
+        'http://us-theonion.videoplaza.tv/proxy/distributor/v2?rt=vast_2.0&tt=p&t=1125,the-onion,today-now,main,html5&s=main/the-onion/today-now?rt=vast_2.0' // eslint-disable-line max-len
       );
     });
   });
@@ -373,7 +379,7 @@ describe('Google Analytics', () => {
     it('sends an "aderror" event without making any change if no rnd value', () => {
       eventStub = {
         tag:
-          'http://us-theonion.videoplaza.tv/proxy/distributor/v2?rt=vast_2.0&tt=p&t=1125,the-onion,today-now,main,html5&s=main/the-onion/today-now',
+          'http://us-theonion.videoplaza.tv/proxy/distributor/v2?rt=vast_2.0&tt=p&t=1125,the-onion,today-now,main,html5&s=main/the-onion/today-now', // eslint-disable-line max-len
         message: 'Ad Tag Empty',
       };
 
@@ -383,14 +389,14 @@ describe('Google Analytics', () => {
         'event',
         'Video:The Onion',
         'aderror: Ad Tag Empty',
-        'http://us-theonion.videoplaza.tv/proxy/distributor/v2?rt=vast_2.0&tt=p&t=1125,the-onion,today-now,main,html5&s=main/the-onion/today-now'
+        'http://us-theonion.videoplaza.tv/proxy/distributor/v2?rt=vast_2.0&tt=p&t=1125,the-onion,today-now,main,html5&s=main/the-onion/today-now' // eslint-disable-line max-len
       );
     });
 
     it('sends an "aderror" event filtering out rnd value when at the end', () => {
       eventStub = {
         tag:
-          'http://us-theonion.videoplaza.tv/proxy/distributor/v2?rt=vast_2.0&tt=p&t=1125,the-onion,today-now,main,html5&s=main/the-onion/today-now&rnd=2768879373',
+          'http://us-theonion.videoplaza.tv/proxy/distributor/v2?rt=vast_2.0&tt=p&t=1125,the-onion,today-now,main,html5&s=main/the-onion/today-now&rnd=2768879373', // eslint-disable-line max-len
         message: 'Ad Tag Empty',
       };
 
@@ -400,14 +406,14 @@ describe('Google Analytics', () => {
         'event',
         'Video:The Onion',
         'aderror: Ad Tag Empty',
-        'http://us-theonion.videoplaza.tv/proxy/distributor/v2?rt=vast_2.0&tt=p&t=1125,the-onion,today-now,main,html5&s=main/the-onion/today-now'
+        'http://us-theonion.videoplaza.tv/proxy/distributor/v2?rt=vast_2.0&tt=p&t=1125,the-onion,today-now,main,html5&s=main/the-onion/today-now' // eslint-disable-line max-len
       );
     });
 
     it('sends an "aderror" event filtering out rnd value when sandwiched', () => {
       eventStub = {
         tag:
-          'http://us-theonion.videoplaza.tv/proxy/distributor/v2?rt=vast_2.0&tt=p&t=1125,the-onion,today-now,main,html5&s=main/the-onion/today-now&rnd=2768879373&foo=bar',
+          'http://us-theonion.videoplaza.tv/proxy/distributor/v2?rt=vast_2.0&tt=p&t=1125,the-onion,today-now,main,html5&s=main/the-onion/today-now&rnd=2768879373&foo=bar', // eslint-disable-line max-len
         message: 'Ad Tag Empty',
       };
 
@@ -417,7 +423,7 @@ describe('Google Analytics', () => {
         'event',
         'Video:The Onion',
         'aderror: Ad Tag Empty',
-        'http://us-theonion.videoplaza.tv/proxy/distributor/v2?rt=vast_2.0&tt=p&t=1125,the-onion,today-now,main,html5&s=main/the-onion/today-now&foo=bar'
+        'http://us-theonion.videoplaza.tv/proxy/distributor/v2?rt=vast_2.0&tt=p&t=1125,the-onion,today-now,main,html5&s=main/the-onion/today-now&foo=bar' // eslint-disable-line max-len
       );
     });
   });


### PR DESCRIPTION
@collin @daytonn @kand @MelizzaP ... Will quiet some of the noise with the `aderror` and `adskipped` event logging