### PR TITLE
Fix start percentage reference

### DIFF
--- a/elements/bulbs-splitpic/splitpic.js
+++ b/elements/bulbs-splitpic/splitpic.js
@@ -6,7 +6,7 @@ export function SplitPic (element) {
   let isMoving = false;
   let lastX = 0;
   let lastY = 0;
-  let startPercentage = parseInt(el.attr('data-start-percent'), 10);
+  let startPercentage = el.find('.splitpic-images').eq(0).data('start-percent');
 
   // split the image at the cursor
   function updateSplit (x, isRelative) {


### PR DESCRIPTION
This fixes split pics from starting at the default percentage when a custom percentage was given.