### PR TITLE
Quiz type test outcome fix

### DIFF
--- a/elements/bulbs-quiz/test-quiz.js
+++ b/elements/bulbs-quiz/test-quiz.js
@@ -20,8 +20,8 @@ export default class TestQuiz {
         $elQuestion.attr('data-unanswered', 'true');
         $('input', elAnswer).change(() => {
           // You may only answer once per question:
-          $('input', $elQuestion).prop('disabled', true);
-          $(this).prop('disabled', false);
+          $('input', $elQuestion).attr('readonly', 'readonly');
+          $(this).attr('readonly', null);
           $($elQuestion).attr('data-unanswered', 'false');
 
           // reveal explanation for the the selected answer only


### PR DESCRIPTION
Fixes outcome totaling for test quiz type. jquery's `serializeArray` will not serialize inputs that have been disabled, so I made them readonly instead. Outcome checker will now total them properly.