### PR TITLE
set location.hash if comments are on current page

### DIFF
--- a/elements/share-tools/components/via-disqus.js
+++ b/elements/share-tools/components/via-disqus.js
@@ -12,9 +12,14 @@ export default class CommentViaDisqus extends ShareTool {
 
   share (event) {
     event.preventDefault();
-    window.open(
-      this.shareUrl + '#comments'
-    );
+    if (this.shareUrl === window.location.toString()) {
+      window.location.hash = '#comments';
+    }
+    else {
+      window.open(
+        this.shareUrl + '#comments'
+      );
+    }
   }
 
   render () {

--- a/elements/share-tools/components/via-disqus.test.js
+++ b/elements/share-tools/components/via-disqus.test.js
@@ -38,38 +38,66 @@ describe('<share-tools> <ViaDisqus>', () => {
   describe('share', () => {
     let event;
 
-    beforeEach(() => {
-      let container = document.createElement('div');
-      container.innerHTML = `
-        <share-tools
-          share-url='URL'
-          share-title='Title'
-        >
-          <div id='render-target'></div>
-        </share-tools>
-      `;
-      event = {
-        preventDefault: () => {},
-      };
-      sinon.stub(event, 'preventDefault');
-      sinon.stub(window, 'open');
-      let commentViaDisqus = ReactDOM.render(
-        <CommentViaDisqus/>,
-        container.querySelector('#render-target')
-      );
-      commentViaDisqus.share(event);
+    context('with a share-url', () => {
+      beforeEach(() => {
+        let container = document.createElement('div');
+        container.innerHTML = `
+          <share-tools
+            share-url='URL'
+            share-title='Title'
+          >
+            <div id='render-target'></div>
+          </share-tools>
+        `;
+        event = {
+          preventDefault: () => {},
+        };
+        sinon.stub(event, 'preventDefault');
+        sinon.stub(window, 'open');
+        let commentViaDisqus = ReactDOM.render(
+          <CommentViaDisqus/>,
+          container.querySelector('#render-target')
+        );
+        commentViaDisqus.share(event);
+      });
+
+      afterEach(() => {
+        window.open.restore();
+      });
+
+      it('prevents default', () => {
+        expect(event.preventDefault).to.have.been.called;
+      });
+
+      it('opens a article comments in new tab', () => {
+        expect(window.open).to.have.been.calledWith('URL#comments');
+      });
     });
 
-    afterEach(() => {
-      window.open.restore();
-    });
+    context('shareUrl is current location', () => {
+      beforeEach(() => {
+        let container = document.createElement('div');
+        container.innerHTML = `
+          <share-tools
+            share-title='Title'
+          >
+            <div id='render-target'></div>
+          </share-tools>
+        `;
+        event = {
+          preventDefault: () => {},
+        };
+        let commentViaDisqus = ReactDOM.render(
+          <CommentViaDisqus/>,
+          container.querySelector('#render-target')
+        );
+        commentViaDisqus.share(event);
+      });
 
-    it('prevents default', () => {
-      expect(event.preventDefault).to.have.been.called;
-    });
-
-    it('opens a article comments in new tab', () => {
-      expect(window.open).to.have.been.calledWith('URL#comments');
+      it('sets window.location.hash to "#comments"', () => {
+        expect(window.location.hash).to.eql('#comments');
+        window.location.hash = '#';
+      });
     });
   });
 });


### PR DESCRIPTION
@daytonn @jmelvnsn @shawncook @spra85 

If `<share-via-disqus>` is on the same page the comments are, we don't need to open a new window, just jump to the comments by setting `window.location.hash =  '#comments'`;