### PR TITLE
Enabling VTT Captions and making them the default for the rail player

### DIFF
--- a/elements/bulbs-video/bulbs-video-examples.js
+++ b/elements/bulbs-video/bulbs-video-examples.js
@@ -72,6 +72,20 @@ let examples = {
         `;
       },
     },
+    'VTT Captioning Example': {
+      render () {
+        return `
+          <bulbs-video
+            src="http://localhost:8080/fixtures/bulbs-video/vtt-captioning.json"
+            target-host-channel="right_rail"
+            target-campaign-number="campaign_605759"
+            autoplay
+            muted
+          >
+          </bulbs-video>
+        `;
+      },
+    },
   },
 };
 

--- a/elements/bulbs-video/components/revealed.js
+++ b/elements/bulbs-video/components/revealed.js
@@ -117,6 +117,10 @@ export default class Revealed extends React.Component {
       videoMeta.player_options.muted = true;
     }
 
+    if (this.props.defaultCaptions) {
+      videoMeta.player_options.defaultCaptions = true;
+    }
+
     this.makeVideoPlayer(this.refs.videoContainer, videoMeta);
   }
 
@@ -202,6 +206,23 @@ export default class Revealed extends React.Component {
     return baseUrl;
   }
 
+  extractTrackCaptions (sources, defaultCaptions) {
+    let captions = [];
+
+    sources.forEach(function (source) {
+      if (source.content_type === 'text/vtt') {
+        captions.push({
+          file: source.url,
+          label: 'English',
+          kind: 'captions',
+          default: defaultCaptions || false
+        });
+      }
+    });
+
+    return captions;
+  }
+
   makeVideoPlayer (element, videoMeta) {
     element.id = videoMeta.gaPrefix;
     let player = global.jwplayer(element);
@@ -230,6 +251,11 @@ export default class Revealed extends React.Component {
       primary: 'html5',
       width: '100%',
     };
+
+    let tracks = this.extractTrackCaptions(videoMeta.sources, videoMeta.player_options.defaultCaptions);
+    if (tracks.length > 0) {
+      playerOptions.tracks = tracks;
+    }
 
     if (!this.props.disableSharing) {
       playerOptions.sharing = {

--- a/elements/bulbs-video/components/revealed.js
+++ b/elements/bulbs-video/components/revealed.js
@@ -215,7 +215,7 @@ export default class Revealed extends React.Component {
           file: source.url,
           label: 'English',
           kind: 'captions',
-          default: defaultCaptions || false
+          default: defaultCaptions || false,
         });
       }
     });
@@ -284,6 +284,7 @@ export default class Revealed extends React.Component {
 Revealed.propTypes = {
   autoplay: PropTypes.bool,
   autoplayNext: PropTypes.bool,
+  defaultCaptions: PropTypes.bool,
   disableSharing: PropTypes.bool,
   muted: PropTypes.bool,
   noEndcard: PropTypes.bool,

--- a/elements/bulbs-video/components/revealed.test.js
+++ b/elements/bulbs-video/components/revealed.test.js
@@ -362,7 +362,7 @@ describe('<bulbs-video> <Revealed>', () => {
         ];
       });
 
-      it('returns an empty array', function() {
+      it('returns an empty array', () => {
         let extractedCaptions = Revealed.prototype.extractTrackCaptions.call({}, sources);
         expect(extractedCaptions).to.eql([]);
       });
@@ -414,15 +414,15 @@ describe('<bulbs-video> <Revealed>', () => {
         ];
       });
 
-      it('returns the caption track info', function() {
+      it('returns the caption track info', () => {
         let extractedCaptions = Revealed.prototype.extractTrackCaptions.call({}, sources, false);
         expect(extractedCaptions).to.eql([
           {
             file: 'http://v.theonion.com/onionstudios/video/4053/captioning.vtt',
             label: 'English',
             kind: 'captions',
-            default: false
-          }
+            default: false,
+          },
         ]);
       });
     });
@@ -724,12 +724,12 @@ describe('<bulbs-video> <Revealed>', () => {
         });
       });
 
-      context('with captions in the sources', function() {
+      context('with captions in the sources', () => {
         let extractCaptionsStub;
         let captioningTracks;
 
         beforeEach(() => {
-          let sources = [
+          sources = [
             {
               'file': 'http://v.theonion.com/onionstudios/video/4053/hls_playlist.m3u8',
             },
@@ -737,8 +737,8 @@ describe('<bulbs-video> <Revealed>', () => {
               'file': 'http://v.theonion.com/onionstudios/video/4053/640.mp4',
             },
           ];
-          let extractSourcesStub = sinon.stub().returns(sources);
-          let vastUrlStub = sinon.stub().returns('http://localhost:8080/vast.xml');
+          extractSourcesStub = sinon.stub().returns(sources);
+          vastUrlStub = sinon.stub().returns('http://localhost:8080/vast.xml');
           captioningTracks = [
             {
               'file': 'http://v.theonion.com/onionstudios/video/4053/captioning.vtt',

--- a/elements/bulbs-video/elements/rail-player/components/root.js
+++ b/elements/bulbs-video/elements/rail-player/components/root.js
@@ -30,6 +30,7 @@ export default class Root extends React.Component {
             disableSharing={true}
             muted={true}
             targetHostChannel='right_rail'
+            defaultCaptions={true}
             {...this.props}
           />
         </div>

--- a/elements/bulbs-video/elements/rail-player/components/root.js
+++ b/elements/bulbs-video/elements/rail-player/components/root.js
@@ -53,6 +53,6 @@ Root.displayName = 'RailPlayerRoot';
 Root.propTypes = {
   channel: PropTypes.string,
   recircUrl: PropTypes.string.isRequired,
-  video: PropTypes.object,
   targetCampaignId: PropTypes.string,
+  video: PropTypes.object,
 };

--- a/elements/bulbs-video/elements/rail-player/components/root.test.js
+++ b/elements/bulbs-video/elements/rail-player/components/root.test.js
@@ -60,6 +60,7 @@ describe('<rail-player> <RailPlayerRoot>', () => {
               muted={true}
               disableSharing={true}
               targetHostChannel='right_rail'
+              defaultCaptions={true}
               {...props}
             />
           </div>

--- a/elements/bulbs-video/rail-player-examples.js
+++ b/elements/bulbs-video/rail-player-examples.js
@@ -67,5 +67,19 @@ export default {
         `;
       },
     },
+    'with captioning': {
+      render () {
+        return `
+          <rail-player
+            style="width: 300px; margin: 0 auto;"
+            recirc-url="http://www.onionstudios.com"
+            channel='avclub'
+            src="http://localhost:8080/fixtures/rail-player/with-captioning.json"
+            target-campaign-id="1234"
+          >
+          </rail-player>
+        `;
+      },
+    },
   },
 };

--- a/examples/fixtures/bulbs-video/vtt-captioning.json
+++ b/examples/fixtures/bulbs-video/vtt-captioning.json
@@ -1,0 +1,129 @@
+{
+  "id": 4257,
+  "title": "Watch Coach Speedman make a difference in the life of a young middle manager.",
+  "channel_slug": "onion-labs",
+  "channel_name": "Onion Labs",
+  "channel_logo_url": "http://i.onionstatic.com/onionstudios/215/original/600.png",
+  "series_name": null,
+  "season": null,
+  "series_slug": null,
+  "series_logo_url": null,
+  "sponsor_id": null,
+  "duration": 0,
+  "poster_url": "http://i.onionstatic.com/onionstudios/5218/original/600.jpg",
+  "targeting": {
+    "target_video_id": 4257,
+    "target_host_channel": "main",
+    "target_channel": "onion-labs"
+  },
+  "tags": [
+    "4257",
+    "main",
+    "onion-labs"
+  ],
+  "category": "main/onion-labs",
+  "videojs_options": {
+    "shareUrl": "http://www.onionstudios.com/videos/watch-coach-speedman-make-a-difference-in-the-life-of-a-young-middle-manager-4257",
+    "isDiscoverable": true,
+    "videoId": 4257,
+    "poster": "http://i.onionstatic.com/onionstudios/5218/16x9/800.jpg",
+    "techOrder": [
+      "html5",
+      "flash"
+    ],
+    "pluginConfig": {
+      "videometrix": {
+        "metadata": {
+          "ns_st_ci": "onionstudios.4257",
+          "c3": "onionstudios",
+          "c4": "ONIONLABS"
+        },
+        "id": 6036328
+      },
+      "videoanalytics": {
+        "id": 6036328
+      },
+      "endcard": {
+        "URL": "http://www.onionstudios.com/end-cards/4257/"
+      }
+    }
+  },
+  "player_options": {
+    "poster": "http://i.onionstatic.com/onionstudios/5218/16x9/800.jpg",
+    "shareUrl": "http://www.onionstudios.com/videos/watch-coach-speedman-make-a-difference-in-the-life-of-a-young-middle-manager-4257",
+    "embedCode": "<iframe name=\"embedded\" allowfullscreen webkitallowfullscreen mozallowfullscreen frameborder=\"no\" width=\"480\" height=\"270\" scrolling=\"no\" src=\"http://www.onionstudios.com/embed?id=4257\"></iframe>\n",
+    "comscore": {
+      "metadata": {
+        "ns_st_ci": "onionstudios.4257",
+        "c3": "onionstudios",
+        "c4": "ONIONLABS"
+      },
+      "id": 6036328
+    }
+  },
+  "sources": [
+    {
+      "id": 20178,
+      "url": "http://v.theonion.com/onionstudios/video/4257/640.webm",
+      "content_type": "video/webm",
+      "width": 640,
+      "bitrate": 501,
+      "enabled": true,
+      "is_legacy_source": false,
+      "video": 4257
+    },
+    {
+      "id": 20177,
+      "url": "http://v.theonion.com/onionstudios/video/4257/640.mp4",
+      "content_type": "video/mp4",
+      "width": 640,
+      "bitrate": 521,
+      "enabled": true,
+      "is_legacy_source": false,
+      "video": 4257
+    },
+    {
+      "id": 20179,
+      "url": "http://v.theonion.com/onionstudios/video/4257/720.mp4",
+      "content_type": "720/video/mp4",
+      "width": 1280,
+      "bitrate": 3466,
+      "enabled": true,
+      "is_legacy_source": false,
+      "video": 4257
+    },
+    {
+      "id": 20180,
+      "url": "http://v.theonion.com/onionstudios/video/4257/1080.mp4",
+      "content_type": "1080/video/mp4",
+      "width": 1920,
+      "bitrate": 7906,
+      "enabled": true,
+      "is_legacy_source": false,
+      "video": 4257
+    },
+    {
+      "id": 20176,
+      "url": "http://v.theonion.com/onionstudios/video/4257/hls_playlist.m3u8",
+      "content_type": "application/x-mpegURL",
+      "width": null,
+      "bitrate": null,
+      "enabled": true,
+      "is_legacy_source": false,
+      "video": 4257
+    },
+    {
+      "id": 12345,
+      "url": "https://s3.amazonaws.com/onionstudios/video/4257/102_Speedstick_EP1_Name_Delivery_Textless.vtt",
+      "content_type": "text/vtt",
+      "width": null,
+      "bitrate": null,
+      "enabled": true,
+      "is_legacy_source": false,
+      "video": 4257
+    }
+  ],
+  "tunic_campaign_url": "http://tunic.theonion.com/api/v1/campaign/572/public",
+  "series_url": null,
+  "channel_url": "http://www.onionstudios.com/channels/onion-labs"
+}

--- a/examples/fixtures/rail-player/with-captioning.json
+++ b/examples/fixtures/rail-player/with-captioning.json
@@ -1,0 +1,129 @@
+{
+  "id": 4257,
+  "title": "Watch Coach Speedman make a difference in the life of a young middle manager.",
+  "channel_slug": "onion-labs",
+  "channel_name": "Onion Labs",
+  "channel_logo_url": "http://i.onionstatic.com/onionstudios/215/original/600.png",
+  "series_name": null,
+  "season": null,
+  "series_slug": null,
+  "series_logo_url": null,
+  "sponsor_id": null,
+  "duration": 0,
+  "poster_url": "http://i.onionstatic.com/onionstudios/5218/original/600.jpg",
+  "targeting": {
+    "target_video_id": 4257,
+    "target_host_channel": "main",
+    "target_channel": "onion-labs"
+  },
+  "tags": [
+    "4257",
+    "main",
+    "onion-labs"
+  ],
+  "category": "main/onion-labs",
+  "videojs_options": {
+    "shareUrl": "http://www.onionstudios.com/videos/watch-coach-speedman-make-a-difference-in-the-life-of-a-young-middle-manager-4257",
+    "isDiscoverable": true,
+    "videoId": 4257,
+    "poster": "http://i.onionstatic.com/onionstudios/5218/16x9/800.jpg",
+    "techOrder": [
+      "html5",
+      "flash"
+    ],
+    "pluginConfig": {
+      "videometrix": {
+        "metadata": {
+          "ns_st_ci": "onionstudios.4257",
+          "c3": "onionstudios",
+          "c4": "ONIONLABS"
+        },
+        "id": 6036328
+      },
+      "videoanalytics": {
+        "id": 6036328
+      },
+      "endcard": {
+        "URL": "http://www.onionstudios.com/end-cards/4257/"
+      }
+    }
+  },
+  "player_options": {
+    "poster": "http://i.onionstatic.com/onionstudios/5218/16x9/800.jpg",
+    "shareUrl": "http://www.onionstudios.com/videos/watch-coach-speedman-make-a-difference-in-the-life-of-a-young-middle-manager-4257",
+    "embedCode": "<iframe name=\"embedded\" allowfullscreen webkitallowfullscreen mozallowfullscreen frameborder=\"no\" width=\"480\" height=\"270\" scrolling=\"no\" src=\"http://www.onionstudios.com/embed?id=4257\"></iframe>\n",
+    "comscore": {
+      "metadata": {
+        "ns_st_ci": "onionstudios.4257",
+        "c3": "onionstudios",
+        "c4": "ONIONLABS"
+      },
+      "id": 6036328
+    }
+  },
+  "sources": [
+    {
+      "id": 20178,
+      "url": "http://v.theonion.com/onionstudios/video/4257/640.webm",
+      "content_type": "video/webm",
+      "width": 640,
+      "bitrate": 501,
+      "enabled": true,
+      "is_legacy_source": false,
+      "video": 4257
+    },
+    {
+      "id": 20177,
+      "url": "http://v.theonion.com/onionstudios/video/4257/640.mp4",
+      "content_type": "video/mp4",
+      "width": 640,
+      "bitrate": 521,
+      "enabled": true,
+      "is_legacy_source": false,
+      "video": 4257
+    },
+    {
+      "id": 20179,
+      "url": "http://v.theonion.com/onionstudios/video/4257/720.mp4",
+      "content_type": "720/video/mp4",
+      "width": 1280,
+      "bitrate": 3466,
+      "enabled": true,
+      "is_legacy_source": false,
+      "video": 4257
+    },
+    {
+      "id": 20180,
+      "url": "http://v.theonion.com/onionstudios/video/4257/1080.mp4",
+      "content_type": "1080/video/mp4",
+      "width": 1920,
+      "bitrate": 7906,
+      "enabled": true,
+      "is_legacy_source": false,
+      "video": 4257
+    },
+    {
+      "id": 20176,
+      "url": "http://v.theonion.com/onionstudios/video/4257/hls_playlist.m3u8",
+      "content_type": "application/x-mpegURL",
+      "width": null,
+      "bitrate": null,
+      "enabled": true,
+      "is_legacy_source": false,
+      "video": 4257
+    },
+    {
+      "id": 12345,
+      "url": "https://s3.amazonaws.com/onionstudios/video/4257/102_Speedstick_EP1_Name_Delivery_Textless.vtt",
+      "content_type": "text/vtt",
+      "width": null,
+      "bitrate": null,
+      "enabled": true,
+      "is_legacy_source": false,
+      "video": 4257
+    }
+  ],
+  "tunic_campaign_url": "http://tunic.theonion.com/api/v1/campaign/572/public",
+  "series_url": null,
+  "channel_url": "http://www.onionstudios.com/channels/onion-labs"
+}


### PR DESCRIPTION
@collin @daytonn @kand @MelizzaP.  For Monday review, this PR will enable closed captioning on our video player as an option if it finds a `text/vtt` closed caption track in the list of sources.  It will also make it so the default option of whether to display them is enabled for the rail-player.  Also, docs for reference to JWPlayer are here (https://support.jwplayer.com/customer/portal/articles/1407438-adding-closed-captions)

Test link with an example here: 
http://closed-captioning.test.onionstudios.com/videos/watch-coach-speedman-make-a-difference-in-the-life-of-a-young-middle-manager-4257

You'll need to enable via the `CC` hover in the video player controls