### PR TITLE
update twitter share tools to read from on-page meta tags

### DIFF
--- a/elements/share-tools/components/share-tool.js
+++ b/elements/share-tools/components/share-tool.js
@@ -15,7 +15,15 @@ export default class ShareTool extends React.Component {
   }
 
   get shareTitle () {
-    return this.shareTools.getAttribute('share-title');
+    let shareTitle = this.shareTools.getAttribute('share-title');
+    if (!shareTitle) {
+      let metaTitle = document.querySelector("[property='og:title']");
+      if (metaTitle) {
+        shareTitle = metaTitle.content;
+      }
+    }
+
+    return shareTitle;
   }
 
   hasIcon () {

--- a/elements/share-tools/components/share-tool.test.js
+++ b/elements/share-tools/components/share-tool.test.js
@@ -69,6 +69,25 @@ describe('<share-tools> <ShareTool>', () => {
       it('is the title of the containing share-tools', () => {
         expect(subject.shareTitle).to.eql('Example Thing');
       });
+
+      it('reads from  meta tag if it exists', () => {
+        container.querySelector('[share-title]').removeAttribute('share-title');
+        let metaTag = document.createElement('meta');
+        metaTag.setAttribute('property', 'og:title');
+        metaTag.content = 'Meta Title';
+        document.head.appendChild(metaTag);
+        expect(subject.shareTitle).to.eql('Meta Title');
+        metaTag.remove();
+      });
+
+      it('prefers reading from parent <share-tools>', () => {
+        let metaTag = document.createElement('meta');
+        metaTag.property = 'og:title';
+        metaTag.content = 'Meta Title';
+        document.head.appendChild(metaTag);
+        expect(subject.shareTitle).to.eql('Example Thing');
+        metaTag.remove();
+      });
     });
 
     describe('hasIcon', () => {

--- a/elements/share-tools/components/via-twitter.js
+++ b/elements/share-tools/components/via-twitter.js
@@ -25,24 +25,11 @@ export default class ShareViaTwitter extends ShareTool {
     return null;
   }
 
-  getShareTitle () {
-    if (this.shareTitle) {
-      return this.shareTitle;
-    }
-
-    let metaTitle = document.querySelector("[name='twitter:title']");
-    if (metaTitle) {
-      return metaTitle.content;
-    }
-
-    return this.shareTitle;
-  }
-
   share (event) {
     event.preventDefault();
     window.open(
       TWITTER_BASE +
-      'text=' + this.getShareTitle() + '&url=' + this.shareUrl +
+      'text=' + this.shareTitle + '&url=' + this.shareUrl +
       '&via=' + this.twitterHandle + '&source=webclient',
       'twitter-share',
       'width=550,height=235'

--- a/elements/share-tools/components/via-twitter.js
+++ b/elements/share-tools/components/via-twitter.js
@@ -12,12 +12,38 @@ export default class ShareViaTwitter extends ShareTool {
     this.share = this.share.bind(this);
   }
 
+  get twitterHandle () {
+    if (this.props.twitterHandle) {
+      return this.props.twitterHandle;
+    }
+
+    let twitterSiteMeta = document.querySelector("[name='twitter:site']");
+    if (twitterSiteMeta) {
+      return twitterSiteMeta.content.replace('@', '');
+    }
+
+    return null;
+  }
+
+  getShareTitle () {
+    if (this.shareTitle) {
+      return this.shareTitle;
+    }
+
+    let metaTitle = document.querySelector("[name='twitter:title']");
+    if (metaTitle) {
+      return metaTitle.content;
+    }
+
+    return this.shareTitle;
+  }
+
   share (event) {
     event.preventDefault();
     window.open(
       TWITTER_BASE +
-      'text=' + this.shareTitle + '&url=' + this.shareUrl +
-      '&via=' + this.props.twitterHandle + '&source=webclient',
+      'text=' + this.getShareTitle() + '&url=' + this.shareUrl +
+      '&via=' + this.twitterHandle + '&source=webclient',
       'twitter-share',
       'width=550,height=235'
     );
@@ -39,5 +65,5 @@ export default class ShareViaTwitter extends ShareTool {
 }
 
 ShareViaTwitter.propTypes = Object.assign({}, ShareTool.propTypes, {
-  twitterHandle: PropTypes.string.isRequired,
+  twitterHandle: PropTypes.string,
 });

--- a/elements/share-tools/components/via-twitter.test.js
+++ b/elements/share-tools/components/via-twitter.test.js
@@ -143,26 +143,7 @@ describe('<share-tools> <ViaTwitter>', () => {
     });
 
     it('reads from parent <share-tools>', () => {
-      expect(subject.getShareTitle()).to.eql('Share Title');
-    });
-
-    it('reads from  meta tag if it exists', () => {
-      shareTools.removeAttribute('share-title');
-      let metaTag = document.createElement('meta');
-      metaTag.name = 'twitter:title';
-      metaTag.content = 'Meta Title';
-      document.head.appendChild(metaTag);
-      expect(subject.getShareTitle()).to.eql('Meta Title');
-      metaTag.remove();
-    });
-
-    it('prefers reading from parent <share-tools>', () => {
-      let metaTag = document.createElement('meta');
-      metaTag.name = 'twitter:title';
-      metaTag.content = 'Meta Title';
-      document.head.appendChild(metaTag);
-      expect(subject.getShareTitle()).to.eql('Share Title');
-      metaTag.remove();
+      expect(subject.shareTitle).to.eql('Share Title');
     });
   });
 });

--- a/elements/share-tools/components/via-twitter.test.js
+++ b/elements/share-tools/components/via-twitter.test.js
@@ -9,7 +9,7 @@ describe('<share-tools> <ViaTwitter>', () => {
     let subject = ShareViaTwitter.propTypes;
 
     it('requires a twitterHandle', () => {
-      expect(subject.twitterHandle).to.eql(PropTypes.string.isRequired);
+      expect(subject.twitterHandle).to.eql(PropTypes.string);
     });
   });
 
@@ -78,6 +78,91 @@ describe('<share-tools> <ViaTwitter>', () => {
        'twitter-share',
        'width=550,height=235'
       );
+    });
+  });
+
+  describe('twitterHandle', () => {
+    let subject;
+
+    it('reads twitterHandle from props', () => {
+      subject = new ShareViaTwitter({
+        icon: '',
+        label: '',
+        twitterHandle: 'ShaolinFantastic',
+      });
+      expect(subject.twitterHandle).to.eql('ShaolinFantastic');
+    });
+
+    it('reads from meta tag if it exists', () => {
+      subject = new ShareViaTwitter({
+        icon: '',
+        label: '',
+      });
+      let metaTag = document.createElement('meta');
+      metaTag.name = 'twitter:site';
+      metaTag.content = '@GrandmasterFlash';
+      document.head.appendChild(metaTag);
+      expect(subject.twitterHandle).to.eql('GrandmasterFlash');
+      metaTag.remove();
+    });
+
+    it('favors reading from props', () => {
+      subject = new ShareViaTwitter({
+        icon: '',
+        label: '',
+        twitterHandle: 'ShaolinFantastic',
+      });
+      let metaTag = document.createElement('meta');
+      metaTag.name = 'twitter:site';
+      metaTag.content = '@GrandmasterFlash';
+      document.head.appendChild(metaTag);
+      expect(subject.twitterHandle).to.eql('ShaolinFantastic');
+      metaTag.remove();
+    });
+  });
+
+  describe('getShareTitle', () => {
+    let shareTools;
+    let subject;
+
+    beforeEach(() => {
+      let container = document.createElement('div');
+      container.innerHTML = `
+        <share-tools
+          share-url='//example.org'
+          share-title='Share Title'
+        >
+          <div id='render-target'></div>
+        </share-tools>
+      `;
+      subject = ReactDOM.render(
+        <ShareViaTwitter twitterHandle='real-slim-shady'/>,
+        container.querySelector('#render-target')
+      );
+      shareTools = container.querySelector('share-tools');
+    });
+
+    it('reads from parent <share-tools>', () => {
+      expect(subject.getShareTitle()).to.eql('Share Title');
+    });
+
+    it('reads from  meta tag if it exists', () => {
+      shareTools.removeAttribute('share-title');
+      let metaTag = document.createElement('meta');
+      metaTag.name = 'twitter:title';
+      metaTag.content = 'Meta Title';
+      document.head.appendChild(metaTag);
+      expect(subject.getShareTitle()).to.eql('Meta Title');
+      metaTag.remove();
+    });
+
+    it('prefers reading from parent <share-tools>', () => {
+      let metaTag = document.createElement('meta');
+      metaTag.name = 'twitter:title';
+      metaTag.content = 'Meta Title';
+      document.head.appendChild(metaTag);
+      expect(subject.getShareTitle()).to.eql('Share Title');
+      metaTag.remove();
     });
   });
 });


### PR DESCRIPTION
Hey cool-crew.

Proposal for the twitter share tools. This adds some defaults for 

````html
<share-via-twitter>
```

In the absence of a `twitter-handle` attribute, this will check the page for a `twitter:site` meta tag.

```html
<meta name="twitter:site" content="@TheOnion">
```

A `twitter-handle` defined directly on a `<share-via-twitter>` will take precedence.


And similarly for the `share-title` attribute of `<share-tools>`. Now `<share-via-twitter>` and `<share-via-email>` will look for an og:title and use that as a default.

```html
<meta name="og:title" content="‘I Can’t Do This Anymore,’ Think 320 Million Americans Quietly Going About Day">
```
