### PR TITLE
a <video is="bulbs-cinemagraph"> is born

### DIFF
--- a/elements/bulbs-cinemagraph/README.md
+++ b/elements/bulbs-cinemagraph/README.md
@@ -1,0 +1,14 @@
+Usage
+
+with src attr:
+```html
+<video src="/video.mp4" is="bulbs-cinemagraph" cinemagraph-duration="1.55"/>
+```
+
+with source element
+```html
+<video is="bulbs-cinemagraph" cinemagraph-duration="1.55">
+  <source src="/video.mp4"/>
+</video>
+```
+Duration needs to be figured out and set by hand to prevent the ios polyfill from showing a frame of black at the loop seam.

--- a/elements/bulbs-cinemagraph/bulbs-cinemagraph-examples.js
+++ b/elements/bulbs-cinemagraph/bulbs-cinemagraph-examples.js
@@ -1,6 +1,23 @@
 export default {
   element: 'bulbs-cinemagraph',
   examples: {
+    'out of view': {
+      render () {
+        return `
+          <div
+            style="
+              height: 2000px;
+            "
+          >
+          </div>
+          <video
+            is="bulbs-cinemagraph"
+            cinemagraph-duration="1.55"
+            src="//v.theonion.com/onionstudios/video/4307/640.mp4"
+          />
+        `;
+      },
+    },
     '[src] attribute': {
       render () {
         return `

--- a/elements/bulbs-cinemagraph/bulbs-cinemagraph-examples.js
+++ b/elements/bulbs-cinemagraph/bulbs-cinemagraph-examples.js
@@ -25,4 +25,4 @@ export default {
       },
     },
   },
-}
+};

--- a/elements/bulbs-cinemagraph/bulbs-cinemagraph-examples.js
+++ b/elements/bulbs-cinemagraph/bulbs-cinemagraph-examples.js
@@ -1,0 +1,28 @@
+export default {
+  element: 'bulbs-cinemagraph',
+  examples: {
+    '[src] attribute': {
+      render () {
+        return `
+          <video
+            is="bulbs-cinemagraph"
+            cinemagraph-duration="1.55"
+            src="//v.theonion.com/onionstudios/video/4307/640.mp4"
+          />
+        `;
+      },
+    },
+    '<source> element': {
+      render () {
+        return `
+          <video
+            is="bulbs-cinemagraph"
+            cinemagraph-duration="1.55"
+          >
+            <source src="//v.theonion.com/onionstudios/video/4307/640.mp4"/>
+          </video>
+        `;
+      },
+    },
+  },
+}

--- a/elements/bulbs-cinemagraph/bulbs-cinemagraph.js
+++ b/elements/bulbs-cinemagraph/bulbs-cinemagraph.js
@@ -26,8 +26,8 @@ class BulbsCinemagraph extends BulbsHTMLVideoElement {
     this.setAttribute('loop', true);
     this.setAttribute('webkit-playsinline', true);
 
-    this.addEventListener('enterviewport', this.handleEnterViewport);
-    this.addEventListener('exitviewport', this.handleExitViewport);
+    this.addEventListener('enterviewport', () => this.play());
+    this.addEventListener('exitviewport', () => this.pause());
   }
 
   attachedCallback () {
@@ -37,14 +37,6 @@ class BulbsCinemagraph extends BulbsHTMLVideoElement {
 
   detachedCallback () {
     InViewMonitor.remove(this);
-  }
-
-  handleEnterViewport () {
-    this.play();
-  }
-
-  handleExitViewport () {
-    this.pause();
   }
 }
 

--- a/elements/bulbs-cinemagraph/bulbs-cinemagraph.js
+++ b/elements/bulbs-cinemagraph/bulbs-cinemagraph.js
@@ -4,7 +4,11 @@ import './bulbs-cinemagraph.scss';
 // Usage:
 // <video src="/path/to/cinemagraph.mp4" is="bulbs-cinemagraph">
 
-class BulbsCinemagraph extends BulbsHTMLElement {
+// We have to do this little dance to properly subclass elements in Safari
+function BulbsHTMLVideoElement () {}
+BulbsHTMLVideoElement.prototype = HTMLVideoElement.prototype;
+
+class BulbsCinemagraph extends BulbsHTMLVideoElement {
   createdCallback () {
     if (!this.hasAttribute('cinemagraph-duration')) {
       console.warn('is="bulbs-cinemagraph" elements should have a [cinemagraph-duration] attribute set');

--- a/elements/bulbs-cinemagraph/bulbs-cinemagraph.js
+++ b/elements/bulbs-cinemagraph/bulbs-cinemagraph.js
@@ -1,0 +1,35 @@
+import { BulbsHTMLElement, registerElement } from 'bulbs-elements/register';
+import makeVideoPlayableInline from 'iphone-inline-video';
+import './bulbs-cinemagraph.scss';
+// Usage:
+// <video src="/path/to/cinemagraph.mp4" is="bulbs-cinemagraph">
+
+class BulbsCinemagraph extends BulbsHTMLElement {
+  createdCallback () {
+    if (!this.hasAttribute('cinemagraph-duration')) {
+      console.warn('is="bulbs-cinemagraph" elements should have a [cinemagraph-duration] attribute set');
+    }
+
+    // makeVideoPlayableInline is dumb and goes just a little bit too far in the
+    // video, this results in a quick flash of a black frame in the loop. If we
+    // override the duration we can get the loop to loop properly.
+    // For now, this must be determined by hand.
+    Object.defineProperty(this, 'duration', {
+      get () {
+        return parseFloat(this.getAttribute('cinemagraph-duration')) || 0;
+      },
+    });
+
+    this.setAttribute('loop', true);
+    this.setAttribute('autoplay', true);
+    this.setAttribute('webkit-playsinline', true);
+  }
+
+  attachedCallback () {
+    makeVideoPlayableInline(this, /* hasAudio */ false);
+  }
+}
+
+BulbsCinemagraph.extends = 'video';
+
+registerElement('bulbs-cinemagraph', BulbsCinemagraph);

--- a/elements/bulbs-cinemagraph/bulbs-cinemagraph.js
+++ b/elements/bulbs-cinemagraph/bulbs-cinemagraph.js
@@ -1,8 +1,7 @@
-import { BulbsHTMLElement, registerElement } from 'bulbs-elements/register';
-import makeVideoPlayableInline from 'iphone-inline-video';
+import { registerElement } from 'bulbs-elements/register';
+import { InViewMonitor } from 'bulbs-elements/util';
+import * as iphoneInlineVideo from 'iphone-inline-video';
 import './bulbs-cinemagraph.scss';
-// Usage:
-// <video src="/path/to/cinemagraph.mp4" is="bulbs-cinemagraph">
 
 // We have to do this little dance to properly subclass elements in Safari
 function BulbsHTMLVideoElement () {}
@@ -25,12 +24,27 @@ class BulbsCinemagraph extends BulbsHTMLVideoElement {
     });
 
     this.setAttribute('loop', true);
-    this.setAttribute('autoplay', true);
     this.setAttribute('webkit-playsinline', true);
+
+    this.addEventListener('enterviewport', this.handleEnterViewport);
+    this.addEventListener('exitviewport', this.handleExitViewport);
   }
 
   attachedCallback () {
-    makeVideoPlayableInline(this, /* hasAudio */ false);
+    iphoneInlineVideo.default(this, /* hasAudio */ false);
+    InViewMonitor.add(this);
+  }
+
+  detachedCallback () {
+    InViewMonitor.remove(this);
+  }
+
+  handleEnterViewport () {
+    this.play();
+  }
+
+  handleExitViewport () {
+    this.pause();
   }
 }
 

--- a/elements/bulbs-cinemagraph/bulbs-cinemagraph.scss
+++ b/elements/bulbs-cinemagraph/bulbs-cinemagraph.scss
@@ -1,0 +1,8 @@
+video[is="bulbs-cinemagraph"] {
+  &::-webkit-media-controls-play-button,
+  &::-webkit-media-controls-start-playback-button {
+    opacity: 0;
+    pointer-events: none;
+    width: 5px;
+  }
+}

--- a/elements/bulbs-cinemagraph/bulbs-cinemagraph.test.js
+++ b/elements/bulbs-cinemagraph/bulbs-cinemagraph.test.js
@@ -1,19 +1,25 @@
-import * as iphoneInlineVideo from 'iphone-inline-video';
+import { InViewMonitor } from 'bulbs-elements/util';
 import './bulbs-cinemagraph';
+import * as iphoneInlineVideo from 'iphone-inline-video';
 
 describe('<video is="bulbs-cinemagraph">', () => {
   let subject;
 
   beforeEach(() => {
     subject = document.createElement('video', 'bulbs-cinemagraph');
+    sinon.spy(InViewMonitor, 'add');
+    sinon.spy(InViewMonitor, 'remove');
+    sinon.spy(subject, 'pause');
+    sinon.spy(subject, 'play');
+  });
+
+  afterEach(() => {
+    InViewMonitor.add.restore();
+    InViewMonitor.remove.restore();
   });
 
   it('sets the loop attribute', () => {
     expect(subject.getAttribute('loop')).to.eql('true');
-  });
-
-  it('sets the autoplay attribute', () => {
-    expect(subject.getAttribute('autoplay')).to.eql('true');
   });
 
   it('sets the webkit-playsinline attribute', () => {
@@ -32,6 +38,32 @@ describe('<video is="bulbs-cinemagraph">', () => {
       let spy = sinon.spy(iphoneInlineVideo, 'default');
       subject.attachedCallback();
       expect(spy).to.have.been.called;
+    });
+
+    it('registers with the InViewMonitor', () => {
+      subject.attachedCallback();
+      expect(InViewMonitor.add).to.have.been.called.once;
+    });
+  });
+
+  describe('detachedCallback', () => {
+    it('removes selve  from InViewMonitor', () => {
+      subject.detachedCallback();
+      expect(InViewMonitor.remove).to.have.been.called.once;
+    });
+  });
+
+  describe('enterviewport event', () => {
+    it('plays the video', () => {
+      subject.dispatchEvent(new CustomEvent('enterviewport'));
+      expect(subject.play).to.have.been.called.once;
+    });
+  });
+
+  describe('exitviewport event', () => {
+    it('pauses the video', () => {
+      subject.dispatchEvent(new CustomEvent('exitviewport'));
+      expect(subject.pause).to.have.been.called.once;
     });
   });
 });

--- a/elements/bulbs-cinemagraph/bulbs-cinemagraph.test.js
+++ b/elements/bulbs-cinemagraph/bulbs-cinemagraph.test.js
@@ -7,6 +7,7 @@ describe('<video is="bulbs-cinemagraph">', () => {
 
   beforeEach(() => {
     subject = document.createElement('video', 'bulbs-cinemagraph');
+    document.body.appendChild(subject);
     sinon.spy(InViewMonitor, 'add');
     sinon.spy(InViewMonitor, 'remove');
     sinon.spy(subject, 'pause');

--- a/elements/bulbs-cinemagraph/bulbs-cinemagraph.test.js
+++ b/elements/bulbs-cinemagraph/bulbs-cinemagraph.test.js
@@ -1,0 +1,28 @@
+describe('<video is="bulbs-cinemagraph">', () => {
+  let subject;
+
+  beforeEach(() => {
+    subject = document.createElement('video', 'bulbs-cinemagraph');
+  });
+
+  it('sets the loop attribute', () => {
+    expect(subject.getAttribute('loop')).to.eql('true');
+  });
+
+  it('sets the autoplay attribute', () => {
+    expect(subject.getAttribute('autoplay')).to.eql('true');
+  });
+
+  it('sets the webkit-playsinline attribute', () => {
+    expect(subject.getAttribute('webkit-playsinline')).to.eql('true');
+  });
+
+  it('overrides the video duration', () => {
+    subject.setAttribute('cinemagraph-duration', '4.55');
+    expect(subject.duration).to.eql(4.55);
+  });
+
+  describe('attachedCallback', () => {
+    // Not sure how to assert the makeVideoPlayableInline function was called.
+  });
+});

--- a/elements/bulbs-cinemagraph/bulbs-cinemagraph.test.js
+++ b/elements/bulbs-cinemagraph/bulbs-cinemagraph.test.js
@@ -1,3 +1,4 @@
+import * as iphoneInlineVideo from 'iphone-inline-video';
 import './bulbs-cinemagraph';
 
 describe('<video is="bulbs-cinemagraph">', () => {
@@ -25,6 +26,12 @@ describe('<video is="bulbs-cinemagraph">', () => {
   });
 
   describe('attachedCallback', () => {
-    // Not sure how to assert the makeVideoPlayableInline function was called.
+    // Can't actually spy on the export like this.
+    // Any testing ideas welcome.
+    xit('calls makeVideoPlayableInline', () => {
+      let spy = sinon.spy(iphoneInlineVideo, 'default');
+      subject.attachedCallback();
+      expect(spy).to.have.been.called;
+    });
   });
 });

--- a/elements/bulbs-cinemagraph/bulbs-cinemagraph.test.js
+++ b/elements/bulbs-cinemagraph/bulbs-cinemagraph.test.js
@@ -1,3 +1,5 @@
+import './bulbs-cinemagraph';
+
 describe('<video is="bulbs-cinemagraph">', () => {
   let subject;
 

--- a/elements/share-tools/components/via-twitter.test.js
+++ b/elements/share-tools/components/via-twitter.test.js
@@ -122,7 +122,6 @@ describe('<share-tools> <ViaTwitter>', () => {
   });
 
   describe('getShareTitle', () => {
-    let shareTools;
     let subject;
 
     beforeEach(() => {
@@ -139,7 +138,6 @@ describe('<share-tools> <ViaTwitter>', () => {
         <ShareViaTwitter twitterHandle='real-slim-shady'/>,
         container.querySelector('#render-target')
       );
-      shareTools = container.querySelector('share-tools');
     });
 
     it('reads from parent <share-tools>', () => {

--- a/lib/bulbs-elements/util/in-view-monitor.js
+++ b/lib/bulbs-elements/util/in-view-monitor.js
@@ -13,13 +13,13 @@ let initialized = false;
 let animationRequest;
 let monitoredItems = {};
 
-const init = () => {
+function init () {
   if (initialized === false) {
     initialized = true;
-    window.addEventListener('scroll', handleDisplayMutation);
+    window.addEventListener('scroll', handleDisplayMutation, true);
     window.addEventListener('resize', handleDisplayMutation);
   }
-};
+}
 
 const maybeEmitEvent = (monitoredItem) => {
   let inView = isElementInViewport(monitoredItem.element, monitoredItem.options);
@@ -35,7 +35,7 @@ const maybeEmitEvent = (monitoredItem) => {
   }
 };
 
-const handleDisplayMutation = () => {
+function handleDisplayMutation () {
   if (!animationRequest) {
     animationRequest = requestAnimationFrame(() => {
       animationRequest = null;
@@ -44,7 +44,7 @@ const handleDisplayMutation = () => {
       });
     });
   }
-};
+}
 
 export default {
   add (element, options = {}) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bulbs-elements",
-  "version": "5.14.0",
+  "version": "5.15.0",
   "description": "Some registerable components for bulbs content types.",
   "main": "lib/bulbs-elements/bulbs-elements.js",
   "repository": "git@github.com:theonion/bulbs-elements.git",

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "yo": "^1.6.0"
   },
   "dependencies": {
+    "iphone-inline-video": "^1.9.3",
     "react-flip-move": "^2.4.0",
     "yo": "^1.6.0"
   }


### PR DESCRIPTION
Usage: This custom element uses the element extension form of custom elements.

So far we've been using fully custom elements.

Stuff like:
```html
 <cool-custom-element></cool-custom-element>
```
and
```js
document.createElement('cool-custom-element');
```

But you can also extend built-in elements, like this:
```html
 <video is="cool-video-extensions"></video>
```
and
```js
document.createElement('video', 'cool-video-exensions');
```
======

Here is how we can do cinemagraphs (that play inline on ios!!!)

with src attr:
```html
<video src="/video.mp4" is="bulbs-cinemagraph" cinemagraph-duration="1.55"/>
```

with source element:
```html
<video is="bulbs-cinemagraph" cinemagraph-duration="1.55">
  <source src="/video.mp4"/>
</video>
```
Duration needs to be figured out and set by hand to prevent the ios polyfill from showing a frame of black at the loop seam.

@shawncook @jmelvnsn @MelizzaP 

Let's get cinemagraphic!