### PR TITLE
a utility that monitors when items enter/exit view

### DIFF
--- a/elements/share-tools/components/via-twitter.test.js
+++ b/elements/share-tools/components/via-twitter.test.js
@@ -122,7 +122,6 @@ describe('<share-tools> <ViaTwitter>', () => {
   });
 
   describe('getShareTitle', () => {
-    let shareTools;
     let subject;
 
     beforeEach(() => {
@@ -139,7 +138,6 @@ describe('<share-tools> <ViaTwitter>', () => {
         <ShareViaTwitter twitterHandle='real-slim-shady'/>,
         container.querySelector('#render-target')
       );
-      shareTools = container.querySelector('share-tools');
     });
 
     it('reads from parent <share-tools>', () => {

--- a/lib/bulbs-elements/util/in-view-monitor.js
+++ b/lib/bulbs-elements/util/in-view-monitor.js
@@ -1,0 +1,65 @@
+const isElementInViewport = (el) => {
+  let rect = el.getBoundingClientRect();
+
+  return rect.bottom > 0 &&
+    rect.right > 0 &&
+    rect.left < (window.innerWidth || document.documentElement.clientWidth) &&
+    rect.top < (window.innerHeight || document.documentElement.clientHeight)
+  ;
+};
+
+let inViewId = 0;
+let initialized = false;
+let animationRequest;
+let all = {};
+
+const init = () => {
+  if (initialized === false) {
+    initialized = true;
+    window.addEventListener('scroll', handleDisplayMutation);
+    window.addEventListener('resize', handleDisplayMutation);
+  }
+};
+
+const maybeEmitEvent = (one) => {
+  let inView = isElementInViewport(one.element);
+  if (inView && one.state === 'init' || one.state === 'out') {
+    one.state = 'in';
+    let event = new Event('enterviewport');
+    one.element.dispatchEvent(event);
+  }
+  else if (!inView && one.state === 'in') {
+    one.state = 'out';
+    let event = new Event('exitviewport');
+    one.element.dispatchEvent(event);
+  }
+};
+
+const handleDisplayMutation = () => {
+  if (!animationRequest) {
+    animationRequest = requestAnimationFrame(() => {
+      animationRequest = null;
+      Object.keys(all).forEach((key) => {
+        maybeEmitEvent(all[key]);
+      });
+    });
+  }
+};
+
+export default {
+  add (element) {
+    init();
+    if (!element._bulbsInView) {
+      element._bulbsInView = ++inViewId;
+    }
+    all[element._bulbsInView] = {
+      element,
+      state: 'init',
+    };
+    maybeEmitEvent(all[element._bulbsInView]);
+  },
+
+  remove (element) {
+    delete all[element._bulbsInView];
+  },
+};

--- a/lib/bulbs-elements/util/in-view-monitor.js
+++ b/lib/bulbs-elements/util/in-view-monitor.js
@@ -1,10 +1,10 @@
-const isElementInViewport = (el) => {
+const isElementInViewport = (el, options) => {
   let rect = el.getBoundingClientRect();
 
-  return rect.bottom > 0 &&
+  return rect.bottom > (options.distanceFromTop || 0) &&
     rect.right > 0 &&
     rect.left < (window.innerWidth || document.documentElement.clientWidth) &&
-    rect.top < (window.innerHeight || document.documentElement.clientHeight)
+    rect.top < (window.innerHeight || document.documentElement.clientHeight) + (options.distanceFromBottom || 0)
   ;
 };
 
@@ -22,8 +22,8 @@ const init = () => {
 };
 
 const maybeEmitEvent = (monitoredItem) => {
-  let inView = isElementInViewport(monitoredItem.element);
-  if (inView && monitoredItem.state === 'init' || monitoredItem.state === 'out') {
+  let inView = isElementInViewport(monitoredItem.element, monitoredItem.options);
+  if (inView && monitoredItem.state === 'out') {
     monitoredItem.state = 'in';
     let event = new CustomEvent('enterviewport');
     monitoredItem.element.dispatchEvent(event);
@@ -47,19 +47,24 @@ const handleDisplayMutation = () => {
 };
 
 export default {
-  add (element) {
+  add (element, options = {}) {
     init();
     if (!element._bulbsInView) {
       element._bulbsInView = ++inViewId;
     }
     monitoredItems[element._bulbsInView] = {
       element,
-      state: 'init',
+      state: 'out',
+      options,
     };
     maybeEmitEvent(monitoredItems[element._bulbsInView]);
   },
 
   remove (element) {
     delete monitoredItems[element._bulbsInView];
+  },
+
+  checkElement (element) {
+    maybeEmitEvent(monitoredItems[element._bulbsInView]);
   },
 };

--- a/lib/bulbs-elements/util/in-view-monitor.js
+++ b/lib/bulbs-elements/util/in-view-monitor.js
@@ -11,7 +11,7 @@ const isElementInViewport = (el) => {
 let inViewId = 0;
 let initialized = false;
 let animationRequest;
-let all = {};
+let monitoredItems = {};
 
 const init = () => {
   if (initialized === false) {
@@ -21,17 +21,17 @@ const init = () => {
   }
 };
 
-const maybeEmitEvent = (one) => {
-  let inView = isElementInViewport(one.element);
-  if (inView && one.state === 'init' || one.state === 'out') {
-    one.state = 'in';
+const maybeEmitEvent = (monitoredItem) => {
+  let inView = isElementInViewport(monitoredItem.element);
+  if (inView && monitoredItem.state === 'init' || monitoredItem.state === 'out') {
+    monitoredItem.state = 'in';
     let event = new Event('enterviewport');
-    one.element.dispatchEvent(event);
+    monitoredItem.element.dispatchEvent(event);
   }
-  else if (!inView && one.state === 'in') {
-    one.state = 'out';
+  else if (!inView && monitoredItem.state === 'in') {
+    monitoredItem.state = 'out';
     let event = new Event('exitviewport');
-    one.element.dispatchEvent(event);
+    monitoredItem.element.dispatchEvent(event);
   }
 };
 
@@ -39,8 +39,8 @@ const handleDisplayMutation = () => {
   if (!animationRequest) {
     animationRequest = requestAnimationFrame(() => {
       animationRequest = null;
-      Object.keys(all).forEach((key) => {
-        maybeEmitEvent(all[key]);
+      Object.keys(monitoredItems).forEach((key) => {
+        maybeEmitEvent(monitoredItems[key]);
       });
     });
   }
@@ -52,14 +52,14 @@ export default {
     if (!element._bulbsInView) {
       element._bulbsInView = ++inViewId;
     }
-    all[element._bulbsInView] = {
+    monitoredItems[element._bulbsInView] = {
       element,
       state: 'init',
     };
-    maybeEmitEvent(all[element._bulbsInView]);
+    maybeEmitEvent(monitoredItems[element._bulbsInView]);
   },
 
   remove (element) {
-    delete all[element._bulbsInView];
+    delete monitoredItems[element._bulbsInView];
   },
 };

--- a/lib/bulbs-elements/util/in-view-monitor.js
+++ b/lib/bulbs-elements/util/in-view-monitor.js
@@ -25,12 +25,12 @@ const maybeEmitEvent = (monitoredItem) => {
   let inView = isElementInViewport(monitoredItem.element);
   if (inView && monitoredItem.state === 'init' || monitoredItem.state === 'out') {
     monitoredItem.state = 'in';
-    let event = new Event('enterviewport');
+    let event = new CustomEvent('enterviewport');
     monitoredItem.element.dispatchEvent(event);
   }
   else if (!inView && monitoredItem.state === 'in') {
     monitoredItem.state = 'out';
-    let event = new Event('exitviewport');
+    let event = new CustomEvent('exitviewport');
     monitoredItem.element.dispatchEvent(event);
   }
 };

--- a/lib/bulbs-elements/util/in-view-monitor.test.js
+++ b/lib/bulbs-elements/util/in-view-monitor.test.js
@@ -16,9 +16,11 @@ describe('InViewMonitor', () => {
 
   beforeEach(() => {
     el = document.createElement('div');
-    el.style.position = 'fixed';
+    el.style.position = 'absolute';
     el.style.height = '10px';
     el.style.width = '10px';
+    el.style.top = '0px';
+    el.style.left = '0px';
     document.body.appendChild(el);
   });
 

--- a/lib/bulbs-elements/util/in-view-monitor.test.js
+++ b/lib/bulbs-elements/util/in-view-monitor.test.js
@@ -116,4 +116,125 @@ describe('InViewMonitor', () => {
       });
     });
   });
+
+  describe('distanceFromTop', () => {
+    let spy;
+
+    beforeEach(() => {
+      spy = sinon.spy();
+    });
+
+    it('emits enterviewport when item is within distance from top', () => {
+      el.addEventListener('enterviewport', spy);
+      el.style.top = '40px';
+      InViewMonitor.add(el, {
+        distanceFromTop: 50,
+      });
+
+      expect(spy).to.not.have.been.called;
+      el.style.top = '51px';
+      InViewMonitor.checkElement(el);
+      expect(spy).to.have.been.called.once;
+    });
+
+    it('emits enterviewport when item is within distance from top (negative distance)', () => {
+      el.addEventListener('enterviewport', spy);
+      el.style.top = '-60px';
+      InViewMonitor.add(el, {
+        distanceFromTop: -50,
+      });
+      expect(spy).not.to.have.been.called.once;
+
+      el.style.top = '-59px';
+      InViewMonitor.checkElement(el);
+      expect(spy).to.have.been.called.once;
+    });
+
+    it('emits exitviewport when item is within distance from top', () => {
+      el.addEventListener('exitviewport', spy);
+      el.style.top = '51px';
+      InViewMonitor.add(el, {
+        distanceFromTop: 50,
+      });
+
+      expect(spy).to.not.have.been.called;
+      el.style.top = '40px';
+      InViewMonitor.checkElement(el);
+      expect(spy).to.have.been.called.once;
+    });
+
+    it('emits exitviewport when item is within distance from top (negative distance)', () => {
+      el.addEventListener('exitviewport', spy);
+      el.style.top = '-59px';
+      InViewMonitor.add(el, {
+        distanceFromTop: -50,
+      });
+      expect(spy).not.to.have.been.called.once;
+
+      el.style.top = '-60px';
+      InViewMonitor.checkElement(el);
+      expect(spy).to.have.been.called.once;
+    });
+  });
+
+  describe('distanceFromBottom', () => {
+    let spy;
+
+    beforeEach(() => {
+      spy = sinon.spy();
+    });
+
+    it('emits enterviewport when item is within distance from bottom', () => {
+      el.addEventListener('enterviewport', spy);
+      el.style.top = window.innerHeight + 50 + 'px';
+      InViewMonitor.add(el, {
+        distanceFromBottom: 50,
+      });
+
+      expect(spy).to.not.have.been.called;
+      el.style.top = window.innerHeight + 49 + 'px';
+      InViewMonitor.checkElement(el);
+      expect(spy).to.have.been.called.once;
+    });
+
+    it('emits enterviewport when item is within distance from bottom (negative distance)', () => {
+      el.addEventListener('enterviewport', spy);
+      el.style.top = window.innerHeight - 50 + 'px';
+      InViewMonitor.add(el, {
+        distanceFromBottom: -50,
+      });
+      expect(spy).not.to.have.been.called.once;
+
+      el.style.top = window.innerHeight - 51 + 'px';
+      InViewMonitor.checkElement(el);
+      expect(spy).to.have.been.called.once;
+    });
+
+    it('emits exitviewport when item is within distance from bottom', () => {
+      el.addEventListener('exitviewport', spy);
+      el.style.top = window.innerHeight + 49 + 'px';
+      InViewMonitor.add(el, {
+        distanceFromBottom: 50,
+      });
+
+      expect(spy).to.not.have.been.called;
+      el.style.top = window.innerHeight + 50 + 'px';
+      InViewMonitor.checkElement(el);
+      expect(spy).to.have.been.called.once;
+    });
+
+    it('emits exitviewport when item is within distance from bottom (negative distance)', () => {
+      el.addEventListener('exitviewport', spy);
+      el.style.top = window.innerHeight - 51 + 'px';
+      InViewMonitor.add(el, {
+        // This test is a getter to prove this works with getters
+        get distanceFromBottom () { return  -50 },
+      });
+      expect(spy).not.to.have.been.called.once;
+
+      el.style.top = window.innerHeight - 50 + 'px';
+      InViewMonitor.checkElement(el);
+      expect(spy).to.have.been.called.once;
+    });
+  });
 });

--- a/lib/bulbs-elements/util/in-view-monitor.test.js
+++ b/lib/bulbs-elements/util/in-view-monitor.test.js
@@ -228,7 +228,7 @@ describe('InViewMonitor', () => {
       el.style.top = window.innerHeight - 51 + 'px';
       InViewMonitor.add(el, {
         // This test is a getter to prove this works with getters
-        get distanceFromBottom () { return  -50 },
+        get distanceFromBottom () { return -50; },
       });
       expect(spy).not.to.have.been.called.once;
 

--- a/lib/bulbs-elements/util/in-view-monitor.test.js
+++ b/lib/bulbs-elements/util/in-view-monitor.test.js
@@ -1,0 +1,107 @@
+/* eslint-disable no-return-assign */
+import InViewMonitor from './in-view-monitor';
+
+describe('InViewMonitor', () => {
+  let el;
+
+  beforeEach(() => {
+    el = document.createElement('div');
+    el.style.position = 'fixed';
+    el.style.height = '10px';
+    el.style.width = '10px';
+    document.body.appendChild(el);
+  });
+
+  afterEach(() => {
+    el.remove();
+  });
+
+  describe('add', () => {
+    it('emits enterviewport event if element already in viewport', () => {
+      let spy = sinon.spy();
+      el.addEventListener('enterviewport', spy);
+      InViewMonitor.add(el);
+      expect(spy).to.have.been.called.once;
+    });
+
+    it('does not emit enterviewport event if element not in viewport', () => {
+      let spy = sinon.spy();
+      el.addEventListener('enterviewport', spy);
+      el.style.top = '200%';
+      InViewMonitor.add(el);
+      expect(spy).not.to.have.been.called.once;
+    });
+
+    it('emits enterviewport event on scroll', (done) => {
+      let spy = sinon.spy();
+      el.addEventListener('enterviewport', spy);
+      el.style.top = '200%';
+      InViewMonitor.add(el);
+      el.style.top = '0';
+      requestAnimationFrame(() => {
+        window.dispatchEvent(new Event('scroll'));
+        requestAnimationFrame(() => {
+          window.dispatchEvent(new Event('scroll'));
+          requestAnimationFrame(() => {
+            expect(spy).to.have.been.called.once;
+            done();
+          });
+        });
+      });
+    });
+
+    it('emits exitviewport event on scroll', (done) => {
+      let spy = sinon.spy();
+      el.addEventListener('exitviewport', spy);
+      el.style.top = '0';
+      InViewMonitor.add(el);
+      el.style.top = '200%';
+      requestAnimationFrame(() => {
+        window.dispatchEvent(new Event('scroll'));
+        requestAnimationFrame(() => {
+          window.dispatchEvent(new Event('scroll'));
+          requestAnimationFrame(() => {
+            expect(spy).to.have.been.called.once;
+            done();
+          });
+        });
+      });
+    });
+
+    it('emits enterviewport event on resize', (done) => {
+      let spy = sinon.spy();
+      el.addEventListener('enterviewport', spy);
+      el.style.top = '200%';
+      InViewMonitor.add(el);
+      el.style.top = '0';
+      requestAnimationFrame(() => {
+        window.dispatchEvent(new Event('resize'));
+        requestAnimationFrame(() => {
+          window.dispatchEvent(new Event('resize'));
+          requestAnimationFrame(() => {
+            expect(spy).to.have.been.called.once;
+            done();
+          });
+        });
+      });
+    });
+
+    it('emits exitviewport event on resize', (done) => {
+      let spy = sinon.spy();
+      el.addEventListener('exitviewport', spy);
+      el.style.top = '0';
+      InViewMonitor.add(el);
+      el.style.top = '200%';
+      requestAnimationFrame(() => {
+        window.dispatchEvent(new Event('resize'));
+        requestAnimationFrame(() => {
+          window.dispatchEvent(new Event('resize'));
+          requestAnimationFrame(() => {
+            expect(spy).to.have.been.called.once;
+            done();
+          });
+        });
+      });
+    });
+  });
+});

--- a/lib/bulbs-elements/util/in-view-monitor.test.js
+++ b/lib/bulbs-elements/util/in-view-monitor.test.js
@@ -124,6 +124,19 @@ describe('InViewMonitor', () => {
       spy = sinon.spy();
     });
 
+    it('calls calculated options on every check', () => {
+      InViewMonitor.add(el, {
+        get distanceFromTop () {
+          spy();
+          return 0;
+        },
+      });
+
+      InViewMonitor.checkElement(el);
+
+      expect(spy).to.have.been.called.twice;
+    });
+
     it('emits enterviewport when item is within distance from top', () => {
       el.addEventListener('enterviewport', spy);
       el.style.top = '40px';
@@ -182,6 +195,19 @@ describe('InViewMonitor', () => {
 
     beforeEach(() => {
       spy = sinon.spy();
+    });
+
+    it('calls calculated options on every check', () => {
+      InViewMonitor.add(el, {
+        get distanceFromBottom () {
+          spy();
+          return 0;
+        },
+      });
+
+      InViewMonitor.checkElement(el);
+
+      expect(spy).to.have.been.called.twice;
     });
 
     it('emits enterviewport when item is within distance from bottom', () => {

--- a/lib/bulbs-elements/util/in-view-monitor.test.js
+++ b/lib/bulbs-elements/util/in-view-monitor.test.js
@@ -1,6 +1,16 @@
 /* eslint-disable no-return-assign */
 import InViewMonitor from './in-view-monitor';
 
+function emitWindowEvent (eventName) {
+  try {
+    window.dispatchEvent(new Event(eventName));
+  }
+  catch (error) {
+    const event = document.createEvent('Event');
+    event.initEvent(eventName, false, true);
+    window.dispatchEvent(event);
+  }
+}
 describe('InViewMonitor', () => {
   let el;
 
@@ -39,9 +49,9 @@ describe('InViewMonitor', () => {
       InViewMonitor.add(el);
       el.style.top = '0';
       requestAnimationFrame(() => {
-        window.dispatchEvent(new Event('scroll'));
+        emitWindowEvent('scroll');
         requestAnimationFrame(() => {
-          window.dispatchEvent(new Event('scroll'));
+          emitWindowEvent('scroll');
           requestAnimationFrame(() => {
             expect(spy).to.have.been.called.once;
             done();
@@ -57,9 +67,9 @@ describe('InViewMonitor', () => {
       InViewMonitor.add(el);
       el.style.top = '200%';
       requestAnimationFrame(() => {
-        window.dispatchEvent(new Event('scroll'));
+        emitWindowEvent('scroll');
         requestAnimationFrame(() => {
-          window.dispatchEvent(new Event('scroll'));
+          emitWindowEvent('scroll');
           requestAnimationFrame(() => {
             expect(spy).to.have.been.called.once;
             done();
@@ -75,9 +85,9 @@ describe('InViewMonitor', () => {
       InViewMonitor.add(el);
       el.style.top = '0';
       requestAnimationFrame(() => {
-        window.dispatchEvent(new Event('resize'));
+        emitWindowEvent('resize');
         requestAnimationFrame(() => {
-          window.dispatchEvent(new Event('resize'));
+          emitWindowEvent('resize');
           requestAnimationFrame(() => {
             expect(spy).to.have.been.called.once;
             done();
@@ -93,9 +103,9 @@ describe('InViewMonitor', () => {
       InViewMonitor.add(el);
       el.style.top = '200%';
       requestAnimationFrame(() => {
-        window.dispatchEvent(new Event('resize'));
+        emitWindowEvent('resize');
         requestAnimationFrame(() => {
-          window.dispatchEvent(new Event('resize'));
+          emitWindowEvent('resize');
           requestAnimationFrame(() => {
             expect(spy).to.have.been.called.once;
             done();

--- a/lib/bulbs-elements/util/index.js
+++ b/lib/bulbs-elements/util/index.js
@@ -1,3 +1,4 @@
+import InViewMonitor from './in-view-monitor';
 import copyAttribute from './copy-attribute';
 import filterBadResponse from './filter-bad-response';
 import getResponseJSON from './get-response-json';
@@ -11,6 +12,7 @@ module.exports = {
   copyAttribute,
   filterBadResponse,
   getResponseJSON,
+  InViewMonitor,
   iterateObject,
   loadOnDemand,
   makeRequest,

--- a/lib/bulbs-elements/util/load-on-demand.test.js
+++ b/lib/bulbs-elements/util/load-on-demand.test.js
@@ -15,7 +15,17 @@ describe('loadOnDemand', () => {
     beforeEach((done) => {
       container = document.createElement('div');
       container.innerHTML = `
-        <div-on-demand></div-on-demand>
+        <div-on-demand
+          style="
+            position: absolute;
+            top: 0px;
+            left: 0px;
+            display: block;
+            width: 10px;
+            height: 10px;
+          "
+        >
+        </div-on-demand>
       `;
       document.body.appendChild(container);
       setImmediate(() => done());
@@ -35,13 +45,17 @@ describe('loadOnDemand', () => {
     beforeEach((done) => {
       container = document.createElement('div');
       container.innerHTML = `
-        <div
+        <div-on-demand
           style="
-            margin-top: 200%
+            position: absolute;
+            top: 200%;
+            left: 0px;
+            display: block;
+            width: 10px;
+            height: 10px;
           "
         >
-          <div-on-demand></div-on-demand>
-        </div>
+        </div-on-demand>
       `;
       document.body.appendChild(container);
       setImmediate(() => done());
@@ -52,7 +66,7 @@ describe('loadOnDemand', () => {
     });
 
     it('loads on scroll', (done) => {
-      container.firstElementChild.style.marginTop = 'auto';
+      container.firstElementChild.style.top = '0px';
       try {
         window.dispatchEvent(new Event('scroll'));
       }
@@ -68,7 +82,7 @@ describe('loadOnDemand', () => {
     });
 
     it('loads on resize', (done) => {
-      container.firstElementChild.style.marginTop = 'auto';
+      container.firstElementChild.style.top = '0px';
       try {
         window.dispatchEvent(new Event('resize'));
       }
@@ -88,13 +102,17 @@ describe('loadOnDemand', () => {
     beforeEach((done) => {
       container = document.createElement('div');
       container.innerHTML = `
-        <div
+        <div-on-demand
           style="
-            margin-top: 200%
+            position: absolute;
+            top: 200%;
+            left: 0px;
+            display: block;
+            width: 10px;
+            height: 10px;
           "
         >
-          <div-on-demand></div-on-demand>
-        </div>
+        </div-on-demand>
       `;
       document.body.appendChild(container);
       setImmediate(() => done());


### PR DESCRIPTION
This utility allows an element to opt into two new events:

`enterviewport`

`exitviewport`

It can be handily used in the lifecycle hooks of an element.

```js
import { InViewMonitor } from 'bulbs-elements/status';

class RealCoolElement extends BulbsHTMLElement {
  attachedCallback () {
    InViewMonitor.add(this);
  }

  detachedCallback () {
    InViewMonitor.remove(this);
  }
}

registerElement('real-cool-element', RealCoolElement);

let coolElement = document.create('real-cool-element');

coolElement.addEventListener('enterviewport', function () {});
coolElement.addEventListener('exitviewport', function () {});
```

This will be used in the `<video is="bulbs-cinemagraph">` to play/pause it when it enters/leaves the viewport.

@kand @daytonn