### PR TITLE
Product shot clickthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,4 +140,6 @@ To start continuous testing:
 $ npm run karma
 ```
 
+You can open the test results in your browser at [localhost:9876/debug.html]().
+
 ### Examples

--- a/elements/campaign-product-shot/campaign-product-shot.js
+++ b/elements/campaign-product-shot/campaign-product-shot.js
@@ -13,7 +13,9 @@ export default class CampaignProductShot extends BulbsHTMLElement {
       'CampaignProductShot.handleRequestSuccess(data): data.product_shot_url is undefined');
     this.innerHTML =
       `<div class='campaign-product-shot'>
-        <img src='${data.product_shot_url}'>
+        <a href='${data.clickthrough_url}'>
+          <img src='${data.product_shot_url}'>
+        </a>
       </div>`;
   }
 

--- a/elements/campaign-product-shot/campaign-product-shot.test.js
+++ b/elements/campaign-product-shot/campaign-product-shot.test.js
@@ -41,4 +41,12 @@ describe('<campaign-product-shot>', function () {
     element.handleRequestSuccess(campaign);
     expect(element.innerHTML).to.contain('http://example.com/prodcut-shot.jpg');
   });
+
+  it('renders a link with given clickthrough url', function () {
+    element.handleRequestSuccess(campaign);
+
+    expect(
+      element.querySelector('a[href="' + campaign.clickthrough_url + '"]')
+    ).to.not.be.null;
+  });
 });


### PR DESCRIPTION
Wraps product shot image in a clickthrough url link.

**Release Type**: _patch_
No breaking changes, no major features.

**New**

1. `campaign-product-shot` element is now aware of a campaign's `clickthrough_url` and will use it to render a wrapping anchor tag.