### PR TITLE
don't lay the carousel track twice

### DIFF
--- a/elements/bulbs-carousel/bulbs-carousel.js
+++ b/elements/bulbs-carousel/bulbs-carousel.js
@@ -15,9 +15,17 @@ export default class BulbsCarousel extends BulbsHTMLElement {
     this.handleClick = this.handleClick.bind(this);
     this.addEventListener('click', this.handleClick);
 
-    this.track = document.createElement('bulbs-carousel-track');
-    moveChildren(this.slider, this.track);
-    this.slider.appendChild(this.track);
+    // bugfix: if this element is recreated from markup, such as by resetting
+    //         its innerHTML, the track will already exist.
+    let track = this.querySelector('bulbs-carousel-track');
+    if (track) {
+      this.track = track;
+    }
+    else {
+      this.track = document.createElement('bulbs-carousel-track');
+      moveChildren(this.slider, this.track);
+      this.slider.appendChild(this.track);
+    }
 
     this.previousButtons = this.getElementsByTagName('bulbs-carousel-previous');
     this.nextButtons = this.getElementsByTagName('bulbs-carousel-next');

--- a/elements/bulbs-carousel/bulbs-carousel.test.js
+++ b/elements/bulbs-carousel/bulbs-carousel.test.js
@@ -96,6 +96,13 @@ describe('<bulbs-carousel>', () => {
         );
       });
     });
+
+    context('called twice', () => {
+      it.only('does not create a second track', () => {
+        subject.createdCallback();
+        expect(subject.querySelector('bulbs-carousel-track bulbs-carousel-track')).to.be.null;
+      });
+    });
   });
 
   describe('attachedCallback', () => {


### PR DESCRIPTION
The <bulbs-carousel> is initialized twice when the Load More button is clicked on special coverage landing pages (because it is recreated by a call to `innerHTML += '...'`.

This makes sure we don't create two carousel tracks when that happens

# Verification:

http://www.theonion.com/special/marketing click "Load More", scroll back up, and see the carousel items get really small.

http://carousel-track-fix.test.theonion.com/special/marketing click "Load More, scroll backup,  and see that the carousel items are not squashed.