### PR TITLE
Added optional attribute for embedded; when enabled, the advertising plugin is disabled

### DIFF
--- a/elements/bulbs-carousel/bulbs-carousel.test.js
+++ b/elements/bulbs-carousel/bulbs-carousel.test.js
@@ -98,7 +98,7 @@ describe('<bulbs-carousel>', () => {
     });
 
     context('called twice', () => {
-      it.only('does not create a second track', () => {
+      it('does not create a second track', () => {
         subject.createdCallback();
         expect(subject.querySelector('bulbs-carousel-track bulbs-carousel-track')).to.be.null;
       });

--- a/elements/bulbs-video/bulbs-video-examples.js
+++ b/elements/bulbs-video/bulbs-video-examples.js
@@ -86,6 +86,17 @@ let examples = {
         `;
       },
     },
+    'Embedded example, no-ad plugin': {
+      render () {
+        return `
+          <bulbs-video
+            src="http://localhost:8080/fixtures/bulbs-video/vast-html5.json"
+            embedded
+          >
+          </bulbs-video>
+        `;
+      },
+    },
   },
 };
 

--- a/elements/bulbs-video/bulbs-video.js
+++ b/elements/bulbs-video/bulbs-video.js
@@ -66,6 +66,7 @@ export default class BulbsVideo extends BulbsElement {
         targetHostChannel={this.props.targetHostChannel}
         targetSpecialCoverage={this.props.targetSpecialCoverage}
         autoplayNext={typeof this.props.twitterHandle === 'string'}
+        embedded={typeof this.props.embedded === 'string'}
         enablePosterMeta={typeof this.props.enablePosterMeta === 'string'}
         disableMetaLink={typeof this.props.disableMetaLink === 'string'}
         muted={typeof this.props.muted === 'string'}
@@ -87,6 +88,7 @@ Object.assign(BulbsVideo, {
     autoplay: PropTypes.string,
     autoplayNext: PropTypes.string,
     disableMetaLink: PropTypes.string,
+    embedded: PropTypes.string,
     enablePosterMeta: PropTypes.string,
     muted: PropTypes.string,
     noEndcard: PropTypes.string,

--- a/elements/bulbs-video/components/revealed.js
+++ b/elements/bulbs-video/components/revealed.js
@@ -97,9 +97,7 @@ export default class Revealed extends React.Component {
       videoMeta.player_options.defaultCaptions = true;
     }
 
-    if (this.props.embedded) {
-      videoMeta.player_options.embedded = true;
-    }
+    videoMeta.player_options.embedded = this.props.embedded;
 
     this.makeVideoPlayer(this.refs.videoContainer, videoMeta);
   }

--- a/elements/bulbs-video/components/revealed.js
+++ b/elements/bulbs-video/components/revealed.js
@@ -97,6 +97,10 @@ export default class Revealed extends React.Component {
       videoMeta.player_options.defaultCaptions = true;
     }
 
+    if (this.props.embedded) {
+      videoMeta.player_options.embedded = true;
+    }
+
     this.makeVideoPlayer(this.refs.videoContainer, videoMeta);
   }
 
@@ -212,12 +216,6 @@ export default class Revealed extends React.Component {
       },
       sources: this.extractSources(videoMeta.sources),
       image: videoMeta.player_options.poster,
-      advertising: {
-        client: 'vast',
-        tag: this.vastUrl(videoMeta),
-        skipoffset: 5,
-        vpaidmode: 'insecure',
-      },
       flashplayer: '//ssl.p.jwpcdn.com/player/v/7.4.3/jwplayer.flash.swf',
       aspectratio: '16:9',
       autostart: true,
@@ -227,6 +225,15 @@ export default class Revealed extends React.Component {
       primary: 'html5',
       width: '100%',
     };
+
+    if (!videoMeta.player_options.embedded) {
+      playerOptions.advertising = {
+        client: 'vast',
+        tag: this.vastUrl(videoMeta),
+        skipoffset: 5,
+        vpaidmode: 'insecure',
+      }
+    }
 
     let tracks = this.extractTrackCaptions(videoMeta.sources, videoMeta.player_options.defaultCaptions);
     if (tracks.length > 0) {
@@ -262,6 +269,7 @@ Revealed.propTypes = {
   autoplayNext: PropTypes.bool,
   defaultCaptions: PropTypes.bool,
   disableSharing: PropTypes.bool,
+  embedded: PropTypes.bool,
   muted: PropTypes.bool,
   noEndcard: PropTypes.bool,
   targetCampaignId: PropTypes.string,

--- a/elements/bulbs-video/components/revealed.js
+++ b/elements/bulbs-video/components/revealed.js
@@ -232,7 +232,7 @@ export default class Revealed extends React.Component {
         tag: this.vastUrl(videoMeta),
         skipoffset: 5,
         vpaidmode: 'insecure',
-      }
+      };
     }
 
     let tracks = this.extractTrackCaptions(videoMeta.sources, videoMeta.player_options.defaultCaptions);

--- a/elements/bulbs-video/components/revealed.test.js
+++ b/elements/bulbs-video/components/revealed.test.js
@@ -36,6 +36,10 @@ describe('<bulbs-video> <Revealed>', () => {
       expect(subject.muted).to.eql(PropTypes.bool);
     });
 
+    it('accepts embedded boolean', () => {
+      expect(subject.embedded).to.eql(PropTypes.bool);
+    });
+
     it('accepts noEndcard boolean', () => {
       expect(subject.noEndcard).to.eql(PropTypes.bool);
     });
@@ -128,6 +132,7 @@ describe('<bulbs-video> <Revealed>', () => {
           twitterHandle: 'twitter',
           autoplay: true,
           autoplayNext: true,
+          embedded: true,
           muted: true,
           defaultCaptions: true,
           video: Object.assign({}, video, {
@@ -230,6 +235,10 @@ describe('<bulbs-video> <Revealed>', () => {
 
         it('passes through the muted value', () => {
           expect(makeVideoPlayerSpy.args[0][1].player_options.muted).to.be.true;
+        });
+
+        it('passes through the embedded value', () => {
+          expect(makeVideoPlayerSpy.args[0][1].player_options.embedded).to.be.true;
         });
 
         it('passes through the defaultCaptions value', () => {
@@ -788,6 +797,38 @@ describe('<bulbs-video> <Revealed>', () => {
         it('does not set sharing configuration', () => {
           let setupOptions = playerSetup.args[0][0];
           expect(setupOptions.sharing).to.be.undefined;
+        });
+      });
+
+      context('embedded setup', () => {
+        beforeEach(() => {
+          videoMeta.player_options.embedded = true;
+          sources = [
+            {
+              'file': 'http://v.theonion.com/onionstudios/video/4053/hls_playlist.m3u8',
+            },
+            {
+              'file': 'http://v.theonion.com/onionstudios/video/4053/640.mp4',
+            },
+          ];
+          extractSourcesStub = sinon.stub().returns(sources);
+          extractTrackCaptionsStub = sinon.stub().returns([]);
+          vastUrlStub = sinon.stub();
+          Revealed.prototype.makeVideoPlayer.call({
+            props: {},
+            extractSources: extractSourcesStub,
+            extractTrackCaptions: extractTrackCaptionsStub,
+            vastUrl: vastUrlStub,
+          }, element, videoMeta);
+        });
+
+        it('does not call the vast url', () => {
+          expect(vastUrlStub.called).be.false;
+        });
+
+        it('does not pass in advertising option', () => {
+          let setupOptions = playerSetup.args[0][0];
+          expect(setupOptions.advertising).to.be.undefined;
         });
       });
     });

--- a/elements/bulbs-video/components/root.js
+++ b/elements/bulbs-video/components/root.js
@@ -33,6 +33,7 @@ Root.propTypes = {
   autoplayNext: PropTypes.bool,
   controller: PropTypes.object.isRequired,
   disableMetaLink: PropTypes.bool,
+  embedded: PropTypes.bool,
   enablePosterMeta: PropTypes.bool,
   muted: PropTypes.bool,
   noEndcard: PropTypes.bool,

--- a/elements/bulbs-video/elements/meta/components/root.js
+++ b/elements/bulbs-video/elements/meta/components/root.js
@@ -51,6 +51,7 @@ VideoMetaRoot.propTypes = {
   campaignTrackAction: PropTypes.string,
   campaignUrl: PropTypes.string,
   disableLink: PropTypes.bool,
+  mobileTitle: PropTypes.string,
   titleTrackAction: PropTypes.string,
   video: PropTypes.object,
 };


### PR DESCRIPTION
@collin @daytonn @kand ... Queueing this up for a Monday review.

The purpose of the embedded attribute is to disable the JWPlayer advertising plugin for our own internal in-line article embedded players.

