### PR TITLE
adjust rail player header styles

### DIFF
--- a/elements/bulbs-video/elements/rail-player/rail-player.scss
+++ b/elements/bulbs-video/elements/rail-player/rail-player.scss
@@ -36,6 +36,7 @@ rail-player {
   display: flex;
   flex-direction: row;
   padding: 8px 0;
+  position: relative;
 }
 
 .rail-player-logo {


### PR DESCRIPTION
# Bug
Rail player button styling is causing a large unattached play button to float around in articles. The fix was to add a style to bulbs-elements styles 

# Verification
Visit here (prod): http://www.avclub.com/article/fleabags-phoebe-waller-bridge-why-her-protagonists-242592
Scroll down until you will see a very large floating play button.

Visit here (test): http://elements-bump.test.avclub.com/article/fleabags-phoebe-waller-bridge-why-her-protagonists-242592

Scroll down and you will not see that giant play button
