### PR TITLE
bulbs-video lazy loading

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,5 @@
 {
-  "presets": ["react", "es2015"],
+  "presets": ["react", "es2015", "stage-2"],
   "plugins": [
     "transform-object-assign",
     "transform-proto-to-assign",

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ Use this if developing elements within `bulbs-elements` locally
 $ ./scripts/webpack-dev-server
 ```
 
+You can access the examples site now by visiting [localhost:8080]().
+
 ## Common Components
 
 Some components can be used in more than one element.

--- a/elements/bulbs-video/bulbs-video-examples.js
+++ b/elements/bulbs-video/bulbs-video-examples.js
@@ -100,6 +100,12 @@ let examples = {
     'Lazy Load': {
       render () {
         return `
+          <div
+              style="text-align: center;">
+            Open the console<br>
+            And inspect the videos<br>
+            To see lazy load<br>
+          </div>
           <marquee
               scrollamount="10"
               style="
@@ -109,8 +115,14 @@ let examples = {
               ">
             SPACE FOR LAZY LOADING EMULATION. SCROLL TO SEE THE VIDEO.
           </marquee>
+          <div>The following video is not lazy loaded:</div>
           <bulbs-video
-            src="http://localhost:8080/fixtures/bulbs-video/clickhole.json">
+              src="http://localhost:8080/fixtures/bulbs-video/clickhole.json"
+              disable-lazy-loading>
+          </bulbs-video>
+          <div>The following video is lazy loaded:</div>
+          <bulbs-video
+              src="http://localhost:8080/fixtures/bulbs-video/clickhole.json">
           </bulbs-video>
         `;
       },

--- a/elements/bulbs-video/bulbs-video-examples.js
+++ b/elements/bulbs-video/bulbs-video-examples.js
@@ -97,6 +97,24 @@ let examples = {
         `;
       },
     },
+    'Lazy Load': {
+      render () {
+        return `
+          <marquee
+              scrollamount="10"
+              style="
+                height: 1000px;
+                font-size: 50px;
+                text-align: center;
+              ">
+            SPACE FOR LAZY LOADING EMULATION. SCROLL TO SEE THE VIDEO.
+          </marquee>
+          <bulbs-video
+            src="http://localhost:8080/fixtures/bulbs-video/clickhole.json">
+          </bulbs-video>
+        `;
+      },
+    },
   },
 };
 

--- a/elements/bulbs-video/bulbs-video.js
+++ b/elements/bulbs-video/bulbs-video.js
@@ -1,7 +1,7 @@
 import React, { PropTypes } from 'react';
 import { registerReactElement } from 'bulbs-elements/register';
 import BulbsElement from 'bulbs-elements/bulbs-element';
-import LoadOnDemand from 'bulbs-elements/util'
+import { loadOnDemand } from 'bulbs-elements/util'
 
 import VideoField from './fields/video';
 import VideoRequest from './fields/video-request';
@@ -73,18 +73,11 @@ export default class BulbsVideo extends BulbsElement {
 
     if (!allProps.disableLazyLoading) {
 
-      return (
-        <LoadOnDemand
-          component={BulbsVideoRoot}
-          componentProps={allProps}
-        />
-      );
+      return loadOnDemand(BulbsVideoRoot)(allProps);
     }
 
     return (
-      <BulbsVideoRoot
-        {...allProps}
-      />
+      <BulbsVideoRoot {...allProps} />
     );
   }
 }

--- a/elements/bulbs-video/bulbs-video.js
+++ b/elements/bulbs-video/bulbs-video.js
@@ -1,6 +1,7 @@
 import React, { PropTypes } from 'react';
 import { registerReactElement } from 'bulbs-elements/register';
 import BulbsElement from 'bulbs-elements/bulbs-element';
+import LoadOnDemand from 'bulbs-elements/util'
 
 import VideoField from './fields/video';
 import VideoRequest from './fields/video-request';
@@ -57,21 +58,32 @@ export default class BulbsVideo extends BulbsElement {
   }
 */
   render () {
+    let allProps = {
+      ...this.props,
+      ...this.state,
+      actions: this.store.actions,
+      autoplayNext: typeof this.props.twitterHandle === 'string',
+      disableLazyLoading: typeof this.props.disableLazyLoading === 'string',
+      disableMetaLink: typeof this.props.disableMetaLink === 'string',
+      embedded: typeof this.props.embedded === 'string',
+      enablePosterMeta: typeof this.props.enablePosterMeta === 'string',
+      muted: typeof this.props.muted === 'string',
+      noEndcard: typeof this.props.noEndcard === 'string',
+    };
+
+    if (!allProps.disableLazyLoading) {
+
+      return (
+        <LoadOnDemand
+          component={BulbsVideoRoot}
+          componentProps={allProps}
+        />
+      );
+    }
+
     return (
       <BulbsVideoRoot
-        {...this.state}
-        twitterHandle={this.props.twitterHandle}
-        targetCampaignId={this.props.targetCampaignId}
-        targetCampaignNumber={this.props.targetCampaignNumber}
-        targetHostChannel={this.props.targetHostChannel}
-        targetSpecialCoverage={this.props.targetSpecialCoverage}
-        autoplayNext={typeof this.props.twitterHandle === 'string'}
-        embedded={typeof this.props.embedded === 'string'}
-        enablePosterMeta={typeof this.props.enablePosterMeta === 'string'}
-        disableMetaLink={typeof this.props.disableMetaLink === 'string'}
-        muted={typeof this.props.muted === 'string'}
-        noEndcard={typeof this.props.noEndcard === 'string'}
-        actions={this.store.actions}
+        {...allProps}
       />
     );
   }
@@ -87,6 +99,7 @@ Object.assign(BulbsVideo, {
   propTypes: {
     autoplay: PropTypes.string,
     autoplayNext: PropTypes.string,
+    disableLazyLoading: PropTypes.string,
     disableMetaLink: PropTypes.string,
     embedded: PropTypes.string,
     enablePosterMeta: PropTypes.string,

--- a/elements/bulbs-video/bulbs-video.js
+++ b/elements/bulbs-video/bulbs-video.js
@@ -58,26 +58,19 @@ export default class BulbsVideo extends BulbsElement {
   }
 */
   render () {
-    let allProps = {
-      ...this.props,
-      ...this.state,
-      actions: this.store.actions,
-      autoplayNext: typeof this.props.twitterHandle === 'string',
-      disableLazyLoading: typeof this.props.disableLazyLoading === 'string',
-      disableMetaLink: typeof this.props.disableMetaLink === 'string',
-      embedded: typeof this.props.embedded === 'string',
-      enablePosterMeta: typeof this.props.enablePosterMeta === 'string',
-      muted: typeof this.props.muted === 'string',
-      noEndcard: typeof this.props.noEndcard === 'string',
-    };
-
-    if (!allProps.disableLazyLoading) {
-
-      return loadOnDemand(BulbsVideoRoot)(allProps);
-    }
 
     return (
-      <BulbsVideoRoot {...allProps} />
+      <BulbsVideoRoot
+        {...this.props}
+        {...this.state}
+        actions={this.store.actions}
+        autoplayNext={typeof this.props.twitterHandle === 'string'}
+        disableMetaLink={typeof this.props.disableMetaLink === 'string'}
+        embedded={typeof this.props.embedded === 'string'}
+        enablePosterMeta={typeof this.props.enablePosterMeta === 'string'}
+        muted={typeof this.props.muted === 'string'}
+        noEndcard={typeof this.props.noEndcard === 'string'}
+        />
     );
   }
 }
@@ -92,7 +85,6 @@ Object.assign(BulbsVideo, {
   propTypes: {
     autoplay: PropTypes.string,
     autoplayNext: PropTypes.string,
-    disableLazyLoading: PropTypes.string,
     disableMetaLink: PropTypes.string,
     embedded: PropTypes.string,
     enablePosterMeta: PropTypes.string,
@@ -107,7 +99,7 @@ Object.assign(BulbsVideo, {
   },
 });
 
-registerReactElement('bulbs-video', BulbsVideo);
+registerReactElement('bulbs-video', loadOnDemand(BulbsVideo));
 
 import './elements/meta';
 import './elements/summary';

--- a/elements/bulbs-video/bulbs-video.test.js
+++ b/elements/bulbs-video/bulbs-video.test.js
@@ -1,7 +1,5 @@
-import React from 'react';
 import BulbsVideo from './bulbs-video';
 import fetchMock from 'fetch-mock';
-import { mount } from 'enzyme';
 
 describe('<bulbs-video>', () => {
   let src = '//example.org/video-src.json';

--- a/elements/bulbs-video/bulbs-video.test.js
+++ b/elements/bulbs-video/bulbs-video.test.js
@@ -90,7 +90,17 @@ describe('<bulbs-video>', () => {
 
       container = document.createElement('div');
 
-      container.innerHTML = `<div style="height: 1000px;"></div>`;
+      container.innerHTML = `
+        <div style="
+            position: absolute;
+            top: 200%;
+            left: 0px;
+            display: block;
+            width: 10px;
+            height: 10px;
+          ">
+        </div>
+      `;
       document.body.appendChild(container);
       setImmediate(() => done());
     });
@@ -104,7 +114,7 @@ describe('<bulbs-video>', () => {
       videoElement.setAttribute('src', src);
       container.appendChild(videoElement);
 
-      container.firstElementChild.style.height = '0px';
+      container.firstElementChild.style.top = '0';
       try {
         window.dispatchEvent(new Event('scroll'));
       }

--- a/elements/bulbs-video/components/cover.js
+++ b/elements/bulbs-video/components/cover.js
@@ -5,7 +5,6 @@ import VideoMetaRoot from '../elements/meta/components/root';
 
 export default function Cover (props) {
   let { video, actions, enablePosterMeta, disableMetaLink } = props;
-  let imageId = parseInt(video.poster_url.match(/\d+/)[0], 10);
   let metaElement;
 
   if (enablePosterMeta) {
@@ -22,7 +21,6 @@ export default function Cover (props) {
     >
       <img
         className='bulbs-video-poster'
-        imageId={imageId}
         src={video.poster_url}
       />
       <div className='bulbs-video-poster-overlay'>

--- a/elements/bulbs-video/components/cover.test.js
+++ b/elements/bulbs-video/components/cover.test.js
@@ -76,7 +76,6 @@ describe('<bulbs-video> <Cover>', function () {
       expect(subject).to.contain(
         <img
           className='bulbs-video-poster'
-          imageId={imageId}
           src={posterUrl}
         />
       );

--- a/lib/bulbs-elements/util/load-on-demand.js
+++ b/lib/bulbs-elements/util/load-on-demand.js
@@ -17,7 +17,7 @@
 // }
 //
 // export default loadOnDemand(ComponentToLoadOnDemand)
-import React from 'react';
+import React, { PropTypes } from 'react';
 
 addEventListener('resize', maybeLoadComponents);
 addEventListener('scroll', maybeLoadComponents, true);
@@ -122,16 +122,28 @@ export class LoadOnDemand extends React.Component {
   }
 }
 
-export default function loadOnDemand (component) {
+Object.assign(LoadOnDemand, {
+  displayName: 'LoadOnDemand',
+  propTypes: {
+    disableLazyLoading: PropTypes.string
+  },
+});
+
+export default function loadOnDemand (Component) {
+
   const wrapped = (props) => { // eslint-disable-line react/no-multi-comp
+    if (typeof props.disableLazyLoading !== 'undefined') {
+      return <Component {...props} />;
+    }
+
     return (
       <LoadOnDemand
-        component={component}
+        component={Component}
         componentProps={props}
       />
     );
   };
 
-  wrapped.displayName = `LoadOnDemand(${component.displayName})`;
+  wrapped.displayName = `LoadOnDemand(${Component.displayName})`;
   return wrapped;
 }

--- a/lib/bulbs-elements/util/load-on-demand.js
+++ b/lib/bulbs-elements/util/load-on-demand.js
@@ -122,13 +122,6 @@ export class LoadOnDemand extends React.Component {
   }
 }
 
-Object.assign(LoadOnDemand, {
-  displayName: 'LoadOnDemand',
-  propTypes: {
-    disableLazyLoading: PropTypes.string
-  },
-});
-
 export default function loadOnDemand (Component) {
 
   const wrapped = (props) => { // eslint-disable-line react/no-multi-comp
@@ -145,5 +138,9 @@ export default function loadOnDemand (Component) {
   };
 
   wrapped.displayName = `LoadOnDemand(${Component.displayName})`;
+  wrapped.propTypes = {
+    disableLazyLoading: PropTypes.string,
+  };
+
   return wrapped;
 }

--- a/lib/bulbs-elements/util/load-on-demand.test.js
+++ b/lib/bulbs-elements/util/load-on-demand.test.js
@@ -134,4 +134,31 @@ describe('loadOnDemand', () => {
       expect(onDemand.length).to.eql(0);
     });
   });
+
+  context('element is given a disable-lazy-loading attribute', () => {
+
+    beforeEach((done) => {
+      container = document.createElement('div');
+      container.innerHTML = `
+        <div-on-demand
+          style="
+            position: absolute;
+            top: 200%;
+            left: 0px;
+            display: block;
+            width: 10px;
+            height: 10px;
+          "
+          disable-lazy-loading
+        >
+        </div-on-demand>
+      `;
+      document.body.appendChild(container);
+      setImmediate(() => done());
+    });
+
+    it('loads immediately', () => {
+      expect(onDemand.length).to.equal(1);
+    });
+  });
 });

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
     "babel-preset-react-hmre": "^1.0.1",
+    "babel-preset-stage-2": "^6.17.0",
     "bower": "^1.7.9",
     "camelcase": "^2.0.1",
     "chai": "^3.4.1",


### PR DESCRIPTION
Implement [`loadOnDemand`](https://github.com/theonion/bulbs-elements/blob/374acbf897b46d6d3ed3d9b92aa80662101765ed/lib/bulbs-elements/util/load-on-demand.js) wrapper for `bulbs-video` to lazy load video elements.

**Release Type**: _patch_
No large-scale new features, updates should not be breaking.

**Updates**

1. `bulbs-video` now implements `loadOnDemand` for lazy loading. Lazy loading will occur by default. If this behavior is not necessary for a particular `bulbs-video`, give the element the `disable-lazy-loading` attribute to prevent lazy loading.

2. Stage 2 features for babel activated.
