### PR TITLE
this PR reloads ads at 30s intervals

### DIFF
--- a/elements/bulbs-dfp/bulbs-dfp.js
+++ b/elements/bulbs-dfp/bulbs-dfp.js
@@ -90,26 +90,19 @@ export default class BulbsDfp extends BulbsHTMLElement {
 
   handleInterval () {
     util.getAnalyticsManager().sendEvent({
-      eventCategory: 'bulbs-dfp-element Metrics',
+      eventCategory: 'bulbs-dfp-element Hot Metrics',
       eventAction: '30-second-refresh-candidate',
       eventLabel: this.dataset.adUnit,
     });
 
     if (this.isViewable) {
       util.getAnalyticsManager().sendEvent({
-        eventCategory: 'bulbs-dfp-element Metrics',
+        eventCategory: 'bulbs-dfp-element Hot Metrics',
         eventAction: '30-second-refresh-triggered',
         eventLabel: this.dataset.adUnit,
       });
-      /* We are taking our time rolling out this change.
-       *  1) we want to make sure the page-speed implications of putting
-       *      bulbs-elements in the critical path for ad loading isn't too heavy
-       *  2) we want to look at analytics to get some idea of how often this will
-       *      happen.
-       *
-       * The eventual strategy will be:
-      this.adsManager.reloadAds(this)
-       */
+
+      this.adsManager.reloadAds(this);
     }
   }
 

--- a/elements/bulbs-dfp/bulbs-dfp.js
+++ b/elements/bulbs-dfp/bulbs-dfp.js
@@ -90,14 +90,14 @@ export default class BulbsDfp extends BulbsHTMLElement {
 
   handleInterval () {
     util.getAnalyticsManager().sendEvent({
-      eventCategory: 'bulbs-dfp-element Hot Metrics',
+      eventCategory: 'bulbs-dfp-element Live Metrics',
       eventAction: '30-second-refresh-candidate',
       eventLabel: this.dataset.adUnit,
     });
 
     if (this.isViewable) {
       util.getAnalyticsManager().sendEvent({
-        eventCategory: 'bulbs-dfp-element Hot Metrics',
+        eventCategory: 'bulbs-dfp-element Live Metrics',
         eventAction: '30-second-refresh-triggered',
         eventLabel: this.dataset.adUnit,
       });

--- a/elements/bulbs-dfp/bulbs-dfp.test.js
+++ b/elements/bulbs-dfp/bulbs-dfp.test.js
@@ -6,6 +6,7 @@ describe('<div is="bulbs-dfp">', () => {
   let element;
   let sandbox;
   let sendEventSpy;
+  let reloadAdsSpy;
 
   beforeEach((done) => {
     sandbox = sinon.sandbox.create();
@@ -19,6 +20,8 @@ describe('<div is="bulbs-dfp">', () => {
     sandbox.stub(util.InViewMonitor, 'add');
     sandbox.stub(util.InViewMonitor, 'remove');
     sendEventSpy = sandbox.spy();
+    reloadAdsSpy = sandbox.spy();
+    window.BULBS_ELEMENTS_ADS_MANAGER = { reloadAds: reloadAdsSpy };
     sandbox.stub(util, 'getAnalyticsManager', () => {
       return { sendEvent: sendEventSpy };
     });
@@ -29,6 +32,7 @@ describe('<div is="bulbs-dfp">', () => {
   afterEach(() => {
     sandbox.restore();
     element.remove();
+    delete window.BULBS_ELEMENTS_ADS_MANAGER;
   });
 
   describe('attachedCallback', () => {
@@ -122,11 +126,11 @@ describe('<div is="bulbs-dfp">', () => {
     });
   });
 
-  describe('what handleInterval', () => {
+  describe('handleInterval', () => {
     it('sends a 30-second-refresh-candidate bulbs-dfp-element Metric', () => {
       element.handleInterval();
       expect(sendEventSpy).to.have.been.calledWith({
-        eventCategory: 'bulbs-dfp-element Metrics',
+        eventCategory: 'bulbs-dfp-element Hot Metrics',
         eventAction: '30-second-refresh-candidate',
         eventLabel: 'test-unit',
       });
@@ -140,10 +144,15 @@ describe('<div is="bulbs-dfp">', () => {
       it('sends a 30-second-refresh-triggered bulbs-dfp-element Metric', () => {
         element.handleInterval();
         expect(sendEventSpy).to.have.been.calledWith({
-          eventCategory: 'bulbs-dfp-element Metrics',
+          eventCategory: 'bulbs-dfp-element Hot Metrics',
           eventAction: '30-second-refresh-triggered',
           eventLabel: 'test-unit',
         });
+      });
+
+      it('reloads ads', () => {
+        element.handleInterval();
+        expect(reloadAdsSpy).to.have.been.calledWith(element).once;
       });
     });
 
@@ -151,7 +160,7 @@ describe('<div is="bulbs-dfp">', () => {
       it('does not a 30-second-refresh-triggered bulbs-dfp-element Metric', () => {
         element.handleInterval();
         expect(sendEventSpy).to.not.have.been.calledWith({
-          eventCategory: 'bulbs-dfp-element Metrics',
+          eventCategory: 'bulbs-dfp-element Hot Metrics',
           eventAction: '30-second-refresh-triggered',
           eventLabel: 'test-unit',
         });

--- a/elements/bulbs-dfp/bulbs-dfp.test.js
+++ b/elements/bulbs-dfp/bulbs-dfp.test.js
@@ -130,7 +130,7 @@ describe('<div is="bulbs-dfp">', () => {
     it('sends a 30-second-refresh-candidate bulbs-dfp-element Metric', () => {
       element.handleInterval();
       expect(sendEventSpy).to.have.been.calledWith({
-        eventCategory: 'bulbs-dfp-element Hot Metrics',
+        eventCategory: 'bulbs-dfp-element Live Metrics',
         eventAction: '30-second-refresh-candidate',
         eventLabel: 'test-unit',
       });
@@ -144,7 +144,7 @@ describe('<div is="bulbs-dfp">', () => {
       it('sends a 30-second-refresh-triggered bulbs-dfp-element Metric', () => {
         element.handleInterval();
         expect(sendEventSpy).to.have.been.calledWith({
-          eventCategory: 'bulbs-dfp-element Hot Metrics',
+          eventCategory: 'bulbs-dfp-element Live Metrics',
           eventAction: '30-second-refresh-triggered',
           eventLabel: 'test-unit',
         });
@@ -160,7 +160,7 @@ describe('<div is="bulbs-dfp">', () => {
       it('does not a 30-second-refresh-triggered bulbs-dfp-element Metric', () => {
         element.handleInterval();
         expect(sendEventSpy).to.not.have.been.calledWith({
-          eventCategory: 'bulbs-dfp-element Hot Metrics',
+          eventCategory: 'bulbs-dfp-element Live Metrics',
           eventAction: '30-second-refresh-triggered',
           eventLabel: 'test-unit',
         });


### PR DESCRIPTION
The first roll out of the 30 second ad refresh only delivered analytics events in place of actually reloading the ads.

In ~ a day or two we should have enough information to turn on the 30 second refresh with confidence. This PR will actually start reloading ads.