### PR TITLE
jw player embeded share tools

### DIFF
--- a/elements/bulbs-video/components/revealed.js
+++ b/elements/bulbs-video/components/revealed.js
@@ -64,7 +64,7 @@ export default class Revealed extends React.Component {
     let videoMeta = Object.assign({}, this.props.video);
     videoMeta.hostChannel = hostChannel;
     videoMeta.gaPrefix = gaPrefix;
-    videoMeta.player_options.shareUrl = window.location.href;
+    videoMeta.player_options.shareUrl = `${window.location.href}/v/${videoMeta.id}`;
 
     filteredTags.push(hostChannel);
 

--- a/elements/bulbs-video/components/revealed.test.js
+++ b/elements/bulbs-video/components/revealed.test.js
@@ -246,7 +246,8 @@ describe('<bulbs-video> <Revealed>', () => {
         });
 
         it('sets sharetools config', () => {
-          expect(makeVideoPlayerSpy.args[0][1].player_options.shareUrl).to.equal(window.location.href);
+          let expected = `${window.location.href}/v/3124`
+          expect(makeVideoPlayerSpy.args[0][1].player_options.shareUrl).to.equal(expected);
         });
 
         it('sets ga config', () => {

--- a/elements/bulbs-video/components/revealed.test.js
+++ b/elements/bulbs-video/components/revealed.test.js
@@ -246,7 +246,7 @@ describe('<bulbs-video> <Revealed>', () => {
         });
 
         it('sets sharetools config', () => {
-          let expected = `${window.location.href}/v/3124`
+          let expected = `${window.location.href}/v/3124`;
           expect(makeVideoPlayerSpy.args[0][1].player_options.shareUrl).to.equal(expected);
         });
 

--- a/elements/lazy-template/lazy-template.test.js
+++ b/elements/lazy-template/lazy-template.test.js
@@ -1,6 +1,6 @@
 import './lazy-template';
 
-describe.only('<script is="lazy-template">', () => {
+describe('<script is="lazy-template">', () => {
   let sandbox;
   let subject;
   let container;


### PR DESCRIPTION
# Bug
The share tools embeded in the jwplayer were linking to window.location.href as opposed to the video url

# Fix
Added videohub reference id redirect to the jw player share tools

# Verification
In the upper right hand corner of the homepage video player click the share icon and then the facebook or twitter icon. In production it should link link to the homepage, in test it should link to the video url

## Onion
prod: http://www.theonion.com/
test: http://share-toolin.test.theonion.com

## Avclub
prod: http://www.avclub.com/
test: http://share-toolin.test.avclub.com