### PR TITLE
more detailed ads analytics

### DIFF
--- a/elements/bulbs-dfp/bulbs-dfp.js
+++ b/elements/bulbs-dfp/bulbs-dfp.js
@@ -24,9 +24,15 @@ export default class BulbsDfp extends BulbsHTMLElement {
     this.handleEnterViewport = this.handleEnterViewport.bind(this);
     this.handleExitViewport = this.handleExitViewport.bind(this);
     this.handleInterval = this.handleInterval.bind(this);
+    this.handleSlotRenderEnded = this.handleSlotRenderEnded.bind(this);
+    this.handleImpressionViewable = this.handleImpressionViewable.bind(this);
+    this.handleSlotOnload = this.handleSlotOnload.bind(this);
 
     this.addEventListener('enterviewport', this.handleEnterViewport);
     this.addEventListener('exitviewport', this.handleExitViewport);
+    this.addEventListener('dfpSlotRenderEnded', this.handleSlotRenderEnded);
+    this.addEventListener('dfpImpressionViewable', this.handleImpressionViewable);
+    this.addEventListener('dfpSlotOnload', this.handleSlotOnload);
 
     let threshold = parseFloat(this.getAttribute('viewport-threshold'), 10);
     util.InViewMonitor.add(this, {
@@ -88,17 +94,43 @@ export default class BulbsDfp extends BulbsHTMLElement {
      */
   }
 
-  handleInterval () {
+  handleSlotRenderEnded () {
     util.getAnalyticsManager().sendEvent({
       eventCategory: 'bulbs-dfp-element Metrics',
-      eventAction: '30-second-refresh-candidate',
+      eventAction: 'slotrenderended',
+      eventLabel: this.dataset.adUnit,
+    });
+  }
+
+  handleImpressionViewable () {
+    util.getAnalyticsManager().sendEvent({
+      eventCategory: 'bulbs-dfp-element Metrics',
+      eventAction: 'impressionviewable',
+      eventLabel: this.dataset.adUnit,
+    });
+  }
+
+  handleSlotOnload () {
+    util.getAnalyticsManager().sendEvent({
+      eventCategory: 'bulbs-dfp-element Metrics',
+      eventAction: 'slotonload',
+      eventLabel: this.dataset.adUnit,
+    });
+  }
+
+  handleInterval () {
+    let browserVisibility = document.visibilityState;
+
+    util.getAnalyticsManager().sendEvent({
+      eventCategory: 'bulbs-dfp-element Metrics',
+      eventAction: `30-second-refresh-candidate-${browserVisibility}`,
       eventLabel: this.dataset.adUnit,
     });
 
     if (this.isViewable) {
       util.getAnalyticsManager().sendEvent({
         eventCategory: 'bulbs-dfp-element Metrics',
-        eventAction: '30-second-refresh-triggered',
+        eventAction: `30-second-refresh-triggered-${browserVisibility}`,
         eventLabel: this.dataset.adUnit,
       });
       /* We are taking our time rolling out this change.
@@ -108,7 +140,9 @@ export default class BulbsDfp extends BulbsHTMLElement {
        *      happen.
        *
        * The eventual strategy will be:
-      this.adsManager.reloadAds(this)
+       if (browserVisibility == 'visible') {
+        this.adsManager.reloadAds(this)
+       }
        */
     }
   }

--- a/elements/bulbs-dfp/bulbs-dfp.test.js
+++ b/elements/bulbs-dfp/bulbs-dfp.test.js
@@ -79,6 +79,22 @@ describe('<div is="bulbs-dfp">', () => {
       });
     });
 
+    it('attaches a dfpSlotRenderEnded event', () => {
+      element.attachedCallback();
+      expect(element.addEventListener).to.have.been.calledWith('dfpSlotRenderEnded', element.handleSlotRenderEnded);
+    });
+
+    it('attaches a dfpImpressionViewabl event', () => {
+      element.attachedCallback();
+      expect(element.addEventListener).to.have.been
+        .calledWith('dfpImpressionViewable', element.handleImpressionViewable);
+    });
+
+    it('attaches a dfpSlotOnload event', () => {
+      element.attachedCallback();
+      expect(element.addEventListener).to.have.been.calledWith('dfpSlotOnload', element.handleSlotOnload);
+    });
+
     it('sets a refresh interval', () => {
       element.attachedCallback();
       expect(window.setInterval).to.have.been.calledWith(element.handleInterval, 30000);
@@ -122,12 +138,45 @@ describe('<div is="bulbs-dfp">', () => {
     });
   });
 
-  describe('what handleInterval', () => {
+  describe('handleSlotRenderEnded', () => {
+    it('sends a slotrendered event', () => {
+      element.handleSlotRenderEnded();
+      expect(sendEventSpy).to.have.been.calledWith({
+        eventCategory: 'bulbs-dfp-element Metrics',
+        eventAction: 'slotrenderended',
+        eventLabel: 'test-unit',
+      }).once;
+    });
+  });
+
+  describe('handleImpressionViewable', () => {
+    it('sends an impressionviewable event', () => {
+      element.handleImpressionViewable();
+      expect(sendEventSpy).to.have.been.calledWith({
+        eventCategory: 'bulbs-dfp-element Metrics',
+        eventAction: 'impressionviewable',
+        eventLabel: 'test-unit',
+      }).once;
+    });
+  });
+
+  describe('handleSlotOnload', () => {
+    it('sends a slotonload event', () => {
+      element.handleSlotOnload();
+      expect(sendEventSpy).to.have.been.calledWith({
+        eventCategory: 'bulbs-dfp-element Metrics',
+        eventAction: 'slotonload',
+        eventLabel: 'test-unit',
+      }).once;
+    });
+  });
+
+  describe('handleInterval', () => {
     it('sends a 30-second-refresh-candidate bulbs-dfp-element Metric', () => {
       element.handleInterval();
       expect(sendEventSpy).to.have.been.calledWith({
         eventCategory: 'bulbs-dfp-element Metrics',
-        eventAction: '30-second-refresh-candidate',
+        eventAction: `30-second-refresh-candidate-${document.visibilityState}`,
         eventLabel: 'test-unit',
       });
     });
@@ -141,7 +190,7 @@ describe('<div is="bulbs-dfp">', () => {
         element.handleInterval();
         expect(sendEventSpy).to.have.been.calledWith({
           eventCategory: 'bulbs-dfp-element Metrics',
-          eventAction: '30-second-refresh-triggered',
+          eventAction: `30-second-refresh-triggered-${document.visibilityState}`,
           eventLabel: 'test-unit',
         });
       });
@@ -152,7 +201,7 @@ describe('<div is="bulbs-dfp">', () => {
         element.handleInterval();
         expect(sendEventSpy).to.not.have.been.calledWith({
           eventCategory: 'bulbs-dfp-element Metrics',
-          eventAction: '30-second-refresh-triggered',
+          eventAction: `30-second-refresh-triggered-${document.visibilityState}`,
           eventLabel: 'test-unit',
         });
       });

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "karma-bower": "^1.0.1",
     "karma-browserstack-launcher": "^0.1.9",
     "karma-chai": "^0.1.0",
-    "karma-chai-spies": "^0.1.4",
     "karma-chrome-launcher": "^0.2.2",
     "karma-coverage": "^1.0.0",
     "karma-coveralls": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "author": "Onion Product Team <webtech@theonion.com>",
   "license": "UNLICENSED",
-  "devDependencies": {
+  "dependencies": {
     "all": "0.0.0",
     "array-flatten": "^2.0.0",
     "array.prototype.find": "^2.0.0",
@@ -125,9 +125,7 @@
     "write-file-webpack-plugin": "^3.1.4",
     "yaml-loader": "^0.1.0",
     "yeoman-generator": "^0.22.5",
-    "yo": "^1.6.0"
-  },
-  "dependencies": {
+    "yo": "^1.6.0",
     "firebase": "^3.4.0",
     "iphone-inline-video": "^1.9.3",
     "react-flip-move": "^2.4.0",


### PR DESCRIPTION
This PR:

Handles new events from `bulbs-public-ads-manager`
```js
this.addEventListener('dfpSlotRenderEnded', this.handleSlotRenderEnded);
this.addEventListener('dfpImpressionViewable', this.handleImpressionViewable);
this.addEventListener('dfpSlotOnload', this.handleSlotOnload);
```

And emits analytics events for them: 

```js
handleSlotRenderEnded () {
  util.getAnalyticsManager().sendEvent({
    eventCategory: 'bulbs-dfp-element Metrics',
    eventAction: 'slotrenderended',
    eventLabel: this.dataset.adUnit,
  });
}
```
etc.

Also, this adds to the older analytics events we were sending around 30-second ad refreshing by sorting the events by `document.visibilityState`

```js
let browserVisibility = document.visibilityState;
/*....*/
eventAction: `30-second-refresh-candidate-${browserVisibility}`,
```

@spra85 @daytonn @kand @MelizzaP 