### PR TITLE
Adding an optional attribute not to add a DFP pixel to the DOM

### DIFF
--- a/elements/bulbs-video/bulbs-video.js
+++ b/elements/bulbs-video/bulbs-video.js
@@ -1,7 +1,7 @@
 import React, { PropTypes } from 'react';
 import { registerReactElement } from 'bulbs-elements/register';
 import BulbsElement from 'bulbs-elements/bulbs-element';
-import { loadOnDemand } from 'bulbs-elements/util'
+import { loadOnDemand } from 'bulbs-elements/util';
 
 import VideoField from './fields/video';
 import VideoRequest from './fields/video-request';

--- a/elements/campaign-display/README.md
+++ b/elements/campaign-display/README.md
@@ -62,6 +62,29 @@ will produce:
 </div>
 ```
 
+### No Pixel
+
+```html
+<campaign-display
+  placement="my-custom-placement"
+  src="http://localhost:8080/fixtures/campaign-display/campaign.json"
+  preamble-text="Sponsored by"
+  no-pixel></campaign-display>
+```
+
+will produce: 
+
+```html
+<div class="campaign-display" data-label="http://example.com">
+  <span class="campaign-display-preamble">Sponsored by</span>
+  <span class="campaign-display-sponsor-name">
+    <a href="http://example.com">
+      <span>Example Campaign</span>
+    </a>
+  </span>
+</div>
+```
+
 ### Logo only
 
 ```html

--- a/elements/campaign-display/campaign-display.js
+++ b/elements/campaign-display/campaign-display.js
@@ -53,8 +53,8 @@ Object.assign(CampaignDisplay, {
   propTypes: {
     logoOnly: PropTypes.string,
     nameOnly: PropTypes.string,
-    noPixel: PropTypes.string,
     noLink: PropTypes.string,
+    noPixel: PropTypes.string,
     placement: PropTypes.string.isRequired,
     preambleText: PropTypes.string.isRequired,
     src: PropTypes.string.isRequired,

--- a/elements/campaign-display/campaign-display.js
+++ b/elements/campaign-display/campaign-display.js
@@ -37,6 +37,7 @@ class CampaignDisplay extends BulbsElement {
     let options = Object.assign({}, this.state, this.props, {
       nameOnly: typeof this.props.nameOnly === 'string',
       logoOnly: typeof this.props.logoOnly === 'string',
+      noPixel: typeof this.props.noPixel === 'string',
       noLink: typeof this.props.noLink === 'string',
     });
     return (<CampaignDisplayRoot {...options} />);
@@ -52,6 +53,7 @@ Object.assign(CampaignDisplay, {
   propTypes: {
     logoOnly: PropTypes.string,
     nameOnly: PropTypes.string,
+    noPixel: PropTypes.string,
     noLink: PropTypes.string,
     placement: PropTypes.string.isRequired,
     preambleText: PropTypes.string.isRequired,

--- a/elements/campaign-display/campaign-display.test.js
+++ b/elements/campaign-display/campaign-display.test.js
@@ -36,6 +36,12 @@ describe('<campaign-display>', () => {
     }).to.throw('campaign-display component requires a placement');
   });
 
+  it('accepts a no-pixel attribute', () => {
+    props.noPixel = '';
+    subject = shallow(<CampaignDisplay {...props} campaign={campaign} />);
+    expect(subject).to.have.prop('noPixel', true);
+  });
+
   it('accepts a no-link attribute', () => {
     subject = shallow(<CampaignDisplay {...props} campaign={campaign} />);
     expect(subject).to.have.prop('noLink', true);

--- a/elements/campaign-display/components/campaign-display-root.js
+++ b/elements/campaign-display/components/campaign-display-root.js
@@ -114,6 +114,7 @@ CampaignDisplayRoot.propTypes = {
   }).isRequired,
   logoOnly: PropTypes.bool,
   nameOnly: PropTypes.bool,
+  noLink: PropTypes.bool,
   noPixel: PropTypes.bool,
   placement: PropTypes.string.isRequired,
   preambleText: PropTypes.string.isRequired,

--- a/elements/campaign-display/components/campaign-display-root.js
+++ b/elements/campaign-display/components/campaign-display-root.js
@@ -19,7 +19,11 @@ class CampaignDisplayRoot extends Component {
   }
 
   pixelComponent () {
-    return <DfpPixel campaignId={this.props.campaign.id} placement={this.props.placement} />;
+    if (this.props.noPixel) {
+      return '';
+    } else {
+      return <DfpPixel campaignId={this.props.campaign.id} placement={this.props.placement} />;
+    }
   }
 
   logoComponent () {
@@ -97,6 +101,7 @@ CampaignDisplayRoot.defaultProps = {
   logoOnly: false,
   nameOnly: false,
   noLink: false,
+  noPixel: false,
 };
 
 CampaignDisplayRoot.propTypes = {
@@ -109,7 +114,7 @@ CampaignDisplayRoot.propTypes = {
   }).isRequired,
   logoOnly: PropTypes.bool,
   nameOnly: PropTypes.bool,
-  noLink: PropTypes.bool,
+  noPixel: PropTypes.bool,
   placement: PropTypes.string.isRequired,
   preambleText: PropTypes.string.isRequired,
 };

--- a/elements/campaign-display/components/campaign-display-root.js
+++ b/elements/campaign-display/components/campaign-display-root.js
@@ -21,9 +21,9 @@ class CampaignDisplayRoot extends Component {
   pixelComponent () {
     if (this.props.noPixel) {
       return '';
-    } else {
-      return <DfpPixel campaignId={this.props.campaign.id} placement={this.props.placement} />;
     }
+
+    return <DfpPixel campaignId={this.props.campaign.id} placement={this.props.placement} />;
   }
 
   logoComponent () {

--- a/elements/campaign-display/components/campaign-display-root.test.js
+++ b/elements/campaign-display/components/campaign-display-root.test.js
@@ -212,7 +212,7 @@ describe('<campaign-display> <CampaignDisplayRoot>', () => {
   });
 
   context('with no-pixel set', () => {
-    it('does not render a DFP Pixel', function() {
+    it('does not render a DFP Pixel', () => {
       props.noPixel = true;
       subject = shallow(<CampaignDisplayRoot {...props} />);
       expect(subject).not.to.have.descendants(DfpPixel);

--- a/elements/campaign-display/components/campaign-display-root.test.js
+++ b/elements/campaign-display/components/campaign-display-root.test.js
@@ -210,4 +210,12 @@ describe('<campaign-display> <CampaignDisplayRoot>', () => {
       expect(subject).to.not.be.blank();
     });
   });
+
+  context('with no-pixel set', () => {
+    it('does not render a DFP Pixel', function() {
+      props.noPixel = true;
+      subject = shallow(<CampaignDisplayRoot {...props} />);
+      expect(subject).not.to.have.descendants(DfpPixel);
+    });
+  });
 });


### PR DESCRIPTION
@collin @MelizzaP @kand @daytonn ... Looking for a review on this one.  The purpose of this is to add an optional attribute, `no-pixel` to the campaign-display element that will not add an ad to the DOM unless desired.  The intent is to use this for the slide out navigation on the sites, particularly The Onion.