### PR TITLE
bulbs-dfp refresh-interval optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,6 @@ To start continuous testing:
 $ npm run karma
 ```
 
-You can open the test results in your browser at [localhost:9876/debug.html]().
+You can open the test results in your browser at [http://localhost:9876/debug.html]().
 
 ### Examples

--- a/elements/bulbs-dfp/bulbs-dfp.js
+++ b/elements/bulbs-dfp/bulbs-dfp.js
@@ -42,14 +42,13 @@ export default class BulbsDfp extends BulbsHTMLElement {
       },
     });
 
+    let defaultRefreshInterval = 30000;
     this.adUnitData = this.adsManager.units[this.dataset.adUnit];
-
-    if (!this.adUnitData.refreshDisabled &&
-        typeof this.adUnitData.refreshInterval !== 'undefined') {
+    if (!this.adUnitData.refreshDisabled) {
 
       this.refreshInterval = window.setInterval(
         this.handleInterval,
-        this.adUnitData.refreshInterval
+        this.adUnitData.refreshInterval || defaultRefreshInterval
       );
     }
   }

--- a/elements/bulbs-dfp/bulbs-dfp.js
+++ b/elements/bulbs-dfp/bulbs-dfp.js
@@ -43,7 +43,7 @@ export default class BulbsDfp extends BulbsHTMLElement {
     });
 
     let defaultRefreshInterval = 30000;
-    this.adUnitData = this.adsManager.units[this.dataset.adUnit];
+    this.adUnitData = this.adsManager.adUnits.units[this.dataset.adUnit];
     if (!this.adUnitData.refreshDisabled) {
 
       this.refreshInterval = window.setInterval(

--- a/elements/bulbs-dfp/bulbs-dfp.js
+++ b/elements/bulbs-dfp/bulbs-dfp.js
@@ -7,8 +7,6 @@ import {
 
 export default class BulbsDfp extends BulbsHTMLElement {
   attachedCallback () {
-    invariant(this.hasAttribute('refresh-interval'),
-        '<div is="bulbs-dfp>" MUST specify a `refresh-interval` attribute in ms');
 
     invariant(this.hasAttribute('viewport-threshold'),
         '<div is="bulbs-dfp"> MUST specify a `viewport-threshold` property. ' +
@@ -38,13 +36,18 @@ export default class BulbsDfp extends BulbsHTMLElement {
       },
     });
 
-    let intervalLength = parseFloat(this.getAttribute('refresh-interval', 10));
-    this.refreshInterval = window.setInterval(this.handleInterval, intervalLength);
+    if (this.hasAttribute('refresh-interval')) {
+      let intervalLength = parseFloat(this.getAttribute('refresh-interval', 10));
+      this.refreshInterval = window.setInterval(this.handleInterval, intervalLength);
+    }
   }
 
   detachedCallback () {
     util.InViewMonitor.remove(this);
-    window.clearInterval(this.refreshInterval);
+
+    if (this.refreshInterval) {
+      window.clearInterval(this.refreshInterval);
+    }
   }
 
   handleEnterViewport () {

--- a/elements/bulbs-dfp/bulbs-dfp.js
+++ b/elements/bulbs-dfp/bulbs-dfp.js
@@ -36,8 +36,15 @@ export default class BulbsDfp extends BulbsHTMLElement {
       },
     });
 
-    if (this.hasAttribute('refresh-interval')) {
-      let intervalLength = parseFloat(this.getAttribute('refresh-interval', 10));
+    this.adUnitData = this.adsManager.units[this.dataset.adUnit];
+
+    if (!this.adUnitData.refreshDisabled &&
+        (this.hasAttribute('refresh-interval') ||
+          typeof this.adUnitData.refreshInterval !== 'undefined')) {
+
+      let intervalLength =
+          parseInt(this.getAttribute('refresh-interval'), 10) ||
+            this.adUnitData.refreshInterval;
       this.refreshInterval = window.setInterval(this.handleInterval, intervalLength);
     }
   }

--- a/elements/bulbs-dfp/bulbs-dfp.js
+++ b/elements/bulbs-dfp/bulbs-dfp.js
@@ -39,13 +39,12 @@ export default class BulbsDfp extends BulbsHTMLElement {
     this.adUnitData = this.adsManager.units[this.dataset.adUnit];
 
     if (!this.adUnitData.refreshDisabled &&
-        (this.hasAttribute('refresh-interval') ||
-          typeof this.adUnitData.refreshInterval !== 'undefined')) {
+        typeof this.adUnitData.refreshInterval !== 'undefined') {
 
-      let intervalLength =
-          parseInt(this.getAttribute('refresh-interval'), 10) ||
-            this.adUnitData.refreshInterval;
-      this.refreshInterval = window.setInterval(this.handleInterval, intervalLength);
+      this.refreshInterval = window.setInterval(
+        this.handleInterval,
+        this.adUnitData.refreshInterval
+      );
     }
   }
 

--- a/elements/bulbs-dfp/bulbs-dfp.test.js
+++ b/elements/bulbs-dfp/bulbs-dfp.test.js
@@ -90,6 +90,15 @@ describe('<div is="bulbs-dfp">', () => {
       expect(window.setInterval).to.have.been.calledWith(element.handleInterval, refreshInterval);
     });
 
+    it('ignores refresh interval if ads manager also has refreshDisabled set to true for the slot', () => {
+  
+      window.BULBS_ELEMENTS_ADS_MANAGER.units[adUnitName].refreshInterval = 666;
+      window.BULBS_ELEMENTS_ADS_MANAGER.units[adUnitName].refreshDisabled = true;
+      element.attachedCallback(); 
+
+      expect(window.setInterval.called).to.be.false;
+    });
+
     it('attaches a dfpSlotRenderEnded event', () => {
       element.attachedCallback();
       expect(element.addEventListener).to.have.been.calledWith('dfpSlotRenderEnded', element.handleSlotRenderEnded);

--- a/elements/bulbs-dfp/bulbs-dfp.test.js
+++ b/elements/bulbs-dfp/bulbs-dfp.test.js
@@ -77,16 +77,7 @@ describe('<div is="bulbs-dfp">', () => {
       });
     });
 
-    it('sets a refresh interval', () => {
-      let refreshInterval = 30000;
-
-      element.setAttribute('refresh-interval', '' + refreshInterval);
-      element.attachedCallback();
-
-      expect(window.setInterval).to.have.been.calledWith(element.handleInterval, refreshInterval);
-    });
-
-    it('sets a refresh interval from ads manager if not given as an attribute', () => {
+    it('sets a refresh interval from ads manager', () => {
       let refreshInterval = 30000;
       
       window.BULBS_ELEMENTS_ADS_MANAGER.units[adUnitName].refreshInterval = refreshInterval;

--- a/elements/bulbs-dfp/bulbs-dfp.test.js
+++ b/elements/bulbs-dfp/bulbs-dfp.test.js
@@ -35,7 +35,6 @@ describe('<div is="bulbs-dfp">', () => {
   });
 
   afterEach(() => {
-    delete window.BULBS_ELEMENTS_ADS_MANAGER;
     sandbox.restore();
     element.remove();
     delete window.BULBS_ELEMENTS_ADS_MANAGER;

--- a/elements/bulbs-dfp/bulbs-dfp.test.js
+++ b/elements/bulbs-dfp/bulbs-dfp.test.js
@@ -3,6 +3,7 @@ import util from 'bulbs-elements/util';
 import './bulbs-dfp';
 
 describe('<div is="bulbs-dfp">', () => {
+  let adUnitName = 'test-unit';
   let element;
   let sandbox;
   let sendEventSpy;
@@ -10,8 +11,7 @@ describe('<div is="bulbs-dfp">', () => {
   beforeEach((done) => {
     sandbox = sinon.sandbox.create();
     element = document.createElement('div', 'bulbs-dfp');
-    element.setAttribute('data-ad-unit', 'test-unit');
-    element.setAttribute('refresh-interval', '30000');
+    element.setAttribute('data-ad-unit', adUnitName);
     element.setAttribute('viewport-threshold', '1');
     sandbox.spy(element, 'addEventListener');
     sandbox.stub(window, 'setInterval');
@@ -23,10 +23,16 @@ describe('<div is="bulbs-dfp">', () => {
       return { sendEvent: sendEventSpy };
     });
 
+    window.BULBS_ELEMENTS_ADS_MANAGER = {
+      units: {}
+    };
+    window.BULBS_ELEMENTS_ADS_MANAGER.units[adUnitName] = {};
+
     setImmediate(() => done());
   });
 
   afterEach(() => {
+    delete window.BULBS_ELEMENTS_ADS_MANAGER;
     sandbox.restore();
     element.remove();
   });
@@ -49,7 +55,7 @@ describe('<div is="bulbs-dfp">', () => {
       expect(sendEventSpy).to.have.been.calledWith({
         eventCategory: 'bulbs-dfp-element Metrics',
         eventAction: 'attached',
-        eventLabel: 'test-unit',
+        eventLabel: adUnitName,
       });
     });
 
@@ -72,8 +78,21 @@ describe('<div is="bulbs-dfp">', () => {
     });
 
     it('sets a refresh interval', () => {
+      let refreshInterval = 30000;
+
+      element.setAttribute('refresh-interval', '' + refreshInterval);
       element.attachedCallback();
-      expect(window.setInterval).to.have.been.calledWith(element.handleInterval, 30000);
+
+      expect(window.setInterval).to.have.been.calledWith(element.handleInterval, refreshInterval);
+    });
+
+    it('sets a refresh interval from ads manager if not given as an attribute', () => {
+      let refreshInterval = 30000;
+      
+      window.BULBS_ELEMENTS_ADS_MANAGER.units[adUnitName].refreshInterval = refreshInterval;
+      element.attachedCallback();
+
+      expect(window.setInterval).to.have.been.calledWith(element.handleInterval, refreshInterval);
     });
   });
 
@@ -97,7 +116,7 @@ describe('<div is="bulbs-dfp">', () => {
       expect(sendEventSpy).to.have.been.calledWith({
         eventCategory: 'bulbs-dfp-element Metrics',
         eventAction: 'enterviewport',
-        eventLabel: 'test-unit',
+        eventLabel: adUnitName,
       }).once;
     });
   });
@@ -109,7 +128,7 @@ describe('<div is="bulbs-dfp">', () => {
       expect(sendEventSpy).to.have.been.calledWith({
         eventCategory: 'bulbs-dfp-element Metrics',
         eventAction: 'exitviewport',
-        eventLabel: 'test-unit',
+        eventLabel: adUnitName,
       }).once;
     });
   });
@@ -120,7 +139,7 @@ describe('<div is="bulbs-dfp">', () => {
       expect(sendEventSpy).to.have.been.calledWith({
         eventCategory: 'bulbs-dfp-element Metrics',
         eventAction: '30-second-refresh-candidate',
-        eventLabel: 'test-unit',
+        eventLabel: adUnitName,
       });
     });
 
@@ -134,7 +153,7 @@ describe('<div is="bulbs-dfp">', () => {
         expect(sendEventSpy).to.have.been.calledWith({
           eventCategory: 'bulbs-dfp-element Metrics',
           eventAction: '30-second-refresh-triggered',
-          eventLabel: 'test-unit',
+          eventLabel: adUnitName,
         });
       });
     });
@@ -145,7 +164,7 @@ describe('<div is="bulbs-dfp">', () => {
         expect(sendEventSpy).to.not.have.been.calledWith({
           eventCategory: 'bulbs-dfp-element Metrics',
           eventAction: '30-second-refresh-triggered',
-          eventLabel: 'test-unit',
+          eventLabel: adUnitName,
         });
       });
     });

--- a/elements/bulbs-dfp/bulbs-dfp.test.js
+++ b/elements/bulbs-dfp/bulbs-dfp.test.js
@@ -27,9 +27,11 @@ describe('<div is="bulbs-dfp">', () => {
 
     window.BULBS_ELEMENTS_ADS_MANAGER = {
       reloadAds: reloadAdsSpy,
-      units: {},
+      adUnits: {
+        units: {},
+      },
     };
-    window.BULBS_ELEMENTS_ADS_MANAGER.units[adUnitName] = {};
+    window.BULBS_ELEMENTS_ADS_MANAGER.adUnits.units[adUnitName] = {};
 
     setImmediate(() => done());
   });
@@ -83,7 +85,7 @@ describe('<div is="bulbs-dfp">', () => {
     it('sets a refresh interval from ads manager', () => {
       let refreshInterval = 30000;
       
-      window.BULBS_ELEMENTS_ADS_MANAGER.units[adUnitName].refreshInterval = refreshInterval;
+      window.BULBS_ELEMENTS_ADS_MANAGER.adUnits.units[adUnitName].refreshInterval = refreshInterval;
       element.attachedCallback();
 
       expect(window.setInterval).to.have.been.calledWith(element.handleInterval, refreshInterval);
@@ -91,8 +93,8 @@ describe('<div is="bulbs-dfp">', () => {
 
     it('ignores refresh interval if ads manager also has refreshDisabled set to true for the slot', () => {
   
-      window.BULBS_ELEMENTS_ADS_MANAGER.units[adUnitName].refreshInterval = 666;
-      window.BULBS_ELEMENTS_ADS_MANAGER.units[adUnitName].refreshDisabled = true;
+      window.BULBS_ELEMENTS_ADS_MANAGER.adUnits.units[adUnitName].refreshInterval = 666;
+      window.BULBS_ELEMENTS_ADS_MANAGER.adUnits.units[adUnitName].refreshDisabled = true;
       element.attachedCallback(); 
 
       expect(window.setInterval.called).to.be.false;

--- a/elements/bulbs-dfp/bulbs-dfp.test.js
+++ b/elements/bulbs-dfp/bulbs-dfp.test.js
@@ -99,6 +99,14 @@ describe('<div is="bulbs-dfp">', () => {
       expect(window.setInterval.called).to.be.false;
     });
 
+    it('uses a default refresh interval of 30 seconds if not set in ads manager', () => {
+      let defaultRefreshInterval = 30000;
+
+      element.attachedCallback();
+
+      expect(window.setInterval).to.have.been.calledWith(element.handleInterval, defaultRefreshInterval);
+    });
+
     it('attaches a dfpSlotRenderEnded event', () => {
       element.attachedCallback();
       expect(element.addEventListener).to.have.been.calledWith('dfpSlotRenderEnded', element.handleSlotRenderEnded);

--- a/elements/bulbs-dfp/bulbs-dfp.test.js
+++ b/elements/bulbs-dfp/bulbs-dfp.test.js
@@ -32,14 +32,6 @@ describe('<div is="bulbs-dfp">', () => {
   });
 
   describe('attachedCallback', () => {
-    it('requires a `refresh-interval` attribute', () => {
-      element.removeAttribute('refresh-interval');
-      expect(() => {
-        element.attachedCallback();
-      }).to.throw(
-        '<div is="bulbs-dfp>" MUST specify a `refresh-interval` attribute in ms'
-      );
-    });
 
     it('requires a `viewport-threshold` attribute', () => {
       element.removeAttribute('viewport-threshold');

--- a/elements/bulbs-dfp/bulbs-dfp.test.js
+++ b/elements/bulbs-dfp/bulbs-dfp.test.js
@@ -84,7 +84,7 @@ describe('<div is="bulbs-dfp">', () => {
 
     it('sets a refresh interval from ads manager', () => {
       let refreshInterval = 30000;
-      
+
       window.BULBS_ELEMENTS_ADS_MANAGER.adUnits.units[adUnitName].refreshInterval = refreshInterval;
       element.attachedCallback();
 
@@ -92,10 +92,10 @@ describe('<div is="bulbs-dfp">', () => {
     });
 
     it('ignores refresh interval if ads manager also has refreshDisabled set to true for the slot', () => {
-  
+
       window.BULBS_ELEMENTS_ADS_MANAGER.adUnits.units[adUnitName].refreshInterval = 666;
       window.BULBS_ELEMENTS_ADS_MANAGER.adUnits.units[adUnitName].refreshDisabled = true;
-      element.attachedCallback(); 
+      element.attachedCallback();
 
       expect(window.setInterval.called).to.be.false;
     });


### PR DESCRIPTION
Move `refresh-interval` to ad unit configuration. Will be released in conjunction with https://github.com/theonion/bulbs-public-ads-manager/pull/17.

**Release Type**: _patch_
No large-scale new features or breaking changes. Current usages should fall back to default.

**New**

1. `bulbs-dfp` now reads `refreshInterval` from its ad unit configuration to get an amount of time until the ad should refresh. This will default to 30 seconds.

2. `bulbs-dfp` now reads `refreshDisabled` from its ad unit configuration to prevent the ad unit from refreshing.

**Updates**

1. `bulbs-dfp` no longer reads `refresh-interval` attribute.