### PR TITLE
Unmount bulbs-video

### DIFF
--- a/elements/bulbs-video/components/revealed.js
+++ b/elements/bulbs-video/components/revealed.js
@@ -18,6 +18,13 @@ global.BULBS_ELEMENTS_COMSCORE_ID = '6036328';
 let jwPlayerIdCounter = 0;
 
 export default class Revealed extends React.Component {
+
+  componentWillUnmount () {
+
+    this.player.stop();
+
+  }
+
   componentDidMount () {
 
     invariant(
@@ -203,9 +210,9 @@ export default class Revealed extends React.Component {
 
   makeVideoPlayer (element, videoMeta) {
     element.id = `jw-player-${jwPlayerIdCounter++}`;
-    let player = global.jwplayer(element);
+    this.player = global.jwplayer(element);
 
-    player.videoMeta = videoMeta;
+    this.player.videoMeta = videoMeta;
 
     let playerOptions = {
       key: 'qh5iU62Pyc0P3L4gpOdmw+k4sTpmhl2AURmXpA==',
@@ -245,10 +252,10 @@ export default class Revealed extends React.Component {
       };
     }
 
-    player.setup(playerOptions);
+    this.player.setup(playerOptions);
 
-    GoogleAnalytics.init(player, videoMeta.gaTrackerAction);
-    Comscore.init(player, global.BULBS_ELEMENTS_COMSCORE_ID, videoMeta.player_options.comscore.metadata);
+    GoogleAnalytics.init(this.player, videoMeta.gaTrackerAction);
+    Comscore.init(this.player, global.BULBS_ELEMENTS_COMSCORE_ID, videoMeta.player_options.comscore.metadata);
 
   }
 

--- a/elements/bulbs-video/components/revealed.js
+++ b/elements/bulbs-video/components/revealed.js
@@ -20,9 +20,7 @@ let jwPlayerIdCounter = 0;
 export default class Revealed extends React.Component {
 
   componentWillUnmount () {
-
     this.player.stop();
-
   }
 
   componentDidMount () {

--- a/elements/bulbs-video/components/revealed.test.js
+++ b/elements/bulbs-video/components/revealed.test.js
@@ -333,6 +333,15 @@ describe('<bulbs-video> <Revealed>', () => {
     });
   });
 
+  describe('componentWillUnmount', () => {
+    it('stops the player', () => {
+      let revealed = new Revealed({});
+      revealed.player = { stop: sinon.spy() };
+      revealed.componentWillUnmount();
+      expect(revealed.player.stop).to.have.been.called;
+    });
+  });
+
   describe('extractTrackCaptions', () => {
     let sources;
 

--- a/lib/bulbs-elements/register.js
+++ b/lib/bulbs-elements/register.js
@@ -62,7 +62,10 @@ export function registerReactElement (tagName, ReactComponent) {
       // Unmount Me Maybe. See notes above.
       setImmediate(() => {
         if (!document.body.contains(this)) {
-          this.unmountReactComponent();
+          debugger;
+          setTimeout(function() {
+            this.unmountReactComponent();
+          }, 100);
         }
       });
     }

--- a/lib/bulbs-elements/register.js
+++ b/lib/bulbs-elements/register.js
@@ -58,10 +58,6 @@ export function registerReactElement (tagName, ReactComponent) {
       }
     }
 
-    createdCallback () {
-      this.detachedCallback = this.detachedCallback.bind(this);
-    }
-
     detachedCallback () {
       // Unmount Me Maybe. See notes above.
       setImmediate(() => {
@@ -87,11 +83,11 @@ export function registerReactElement (tagName, ReactComponent) {
     }
 
     unmountReactComponent () {
+      ReactDOM.unmountComponentAtNode(this.mountPoint);
       if (this.reactElement) {
         if (this.reactElement.store) {
           this.reactElement.store.unsubscribeComponent(this.reactElement);
         }
-        ReactDOM.unmountComponentAtNode(this.mountPoint);
         delete this.reactElement;
       }
     }

--- a/lib/bulbs-elements/register.js
+++ b/lib/bulbs-elements/register.js
@@ -66,10 +66,7 @@ export function registerReactElement (tagName, ReactComponent) {
       // Unmount Me Maybe. See notes above.
       setImmediate(() => {
         if (!document.body.contains(this)) {
-          debugger;
-          setTimeout(function() {
-            this.unmountReactComponent();
-          }, 100);
+          this.unmountReactComponent();
         }
       });
     }

--- a/lib/bulbs-elements/register.js
+++ b/lib/bulbs-elements/register.js
@@ -58,6 +58,10 @@ export function registerReactElement (tagName, ReactComponent) {
       }
     }
 
+    createdCallback () {
+      this.detachedCallback = this.detachedCallback.bind(this);
+    }
+
     detachedCallback () {
       // Unmount Me Maybe. See notes above.
       setImmediate(() => {


### PR DESCRIPTION
This fixes an issue where bulbs-video elements were still playing after they had been unmounted. An example can be viewed here: https://github.com/theonion/omni/pull/286

@collin @kand @MelizzaP 