### PR TITLE
Fix double audio bug

### DIFF
--- a/elements/bulbs-video/bulbs-video.js
+++ b/elements/bulbs-video/bulbs-video.js
@@ -26,6 +26,8 @@ export default class BulbsVideo extends BulbsElement {
   componentDidUpdate (prevProps) {
     if (this.props.src !== prevProps.src) {
       setImmediate(() => {
+        // We have to do this in the next execution context to work around timing
+        // issues with jwplayer and tearing down video players
         this.store.actions.resetController();
         this.store.actions.setVideoField(null); // eslint-disable-line no-undefined
         this.initialDispatch();

--- a/elements/bulbs-video/bulbs-video.js
+++ b/elements/bulbs-video/bulbs-video.js
@@ -25,9 +25,11 @@ export default class BulbsVideo extends BulbsElement {
 
   componentDidUpdate (prevProps) {
     if (this.props.src !== prevProps.src) {
-      this.store.actions.resetController();
-      this.store.actions.setVideoField(null); // eslint-disable-line no-undefined
-      this.initialDispatch();
+      setImmediate(() => {
+        this.store.actions.resetController();
+        this.store.actions.setVideoField(null); // eslint-disable-line no-undefined
+        this.initialDispatch();
+      });
     }
   }
 

--- a/elements/bulbs-video/bulbs-video.test.js
+++ b/elements/bulbs-video/bulbs-video.test.js
@@ -72,12 +72,18 @@ describe('<bulbs-video>', () => {
         subject.componentDidUpdate({ src });
       });
 
-      it('fetches video data', () => {
-        expect(fetchSpy).to.have.been.calledWith(newSrc);
+      it('fetches video data', (done) => {
+        setImmediate(() => {
+          expect(fetchSpy).to.have.been.calledWith(newSrc);
+          done();
+        });
       });
 
-      it('resets the controller', () => {
-        expect(resetSpy).to.have.been.called;
+      it('resets the controller', (done) => {
+        setImmediate(() => {
+          expect(resetSpy).to.have.been.called;
+          done();
+        });
       });
     });
   });

--- a/elements/bulbs-video/components/revealed.js
+++ b/elements/bulbs-video/components/revealed.js
@@ -19,9 +19,9 @@ global.BULBS_ELEMENTS_COMSCORE_ID = '6036328';
 let jwPlayerIdCounter = 0;
 
 export default class Revealed extends React.Component {
-
-  componentWillUnmount () {
-    this.player.stop();
+  constructor (props) {
+    super(props);
+    this.forwardJWEvent = this.forwardJWEvent.bind(this);
   }
 
   componentDidMount () {
@@ -106,6 +106,10 @@ export default class Revealed extends React.Component {
     videoMeta.player_options.embedded = this.props.embedded;
 
     this.makeVideoPlayer(this.refs.videoContainer, videoMeta);
+  }
+
+  componentWillUnmount () {
+    this.player.remove();
   }
 
   extractSources (sources) {
@@ -256,11 +260,16 @@ export default class Revealed extends React.Component {
     GoogleAnalytics.init(this.player, videoMeta.gaTrackerAction);
     Comscore.init(this.player, global.BULBS_ELEMENTS_COMSCORE_ID, videoMeta.player_options.comscore.metadata);
 
+    this.player.on('complete', this.forwardJWEvent);
+  }
+
+  forwardJWEvent (event) {
+    this.refs.videoViewport.dispatchEvent(new CustomEvent(`jw-${event.type}`));
   }
 
   render () {
     return (
-      <div className='bulbs-video-viewport'>
+      <div className='bulbs-video-viewport' ref='videoViewport'>
         <div className='bulbs-video-video video-container' ref='videoContainer'>
         </div>
       </div>

--- a/elements/bulbs-video/components/revealed.test.js
+++ b/elements/bulbs-video/components/revealed.test.js
@@ -336,9 +336,9 @@ describe('<bulbs-video> <Revealed>', () => {
   describe('componentWillUnmount', () => {
     it('stops the player', () => {
       let revealed = new Revealed({});
-      revealed.player = { stop: sinon.spy() };
+      revealed.player = { remove: sinon.spy() };
       revealed.componentWillUnmount();
-      expect(revealed.player.stop).to.have.been.called;
+      expect(revealed.player.remove).to.have.been.called;
     });
   });
 
@@ -599,6 +599,7 @@ describe('<bulbs-video> <Revealed>', () => {
 
   describe('makeVideoPlayer', () => {
     let playerSetup;
+    let playerOn;
     let element;
     let player;
     let videoMeta;
@@ -671,7 +672,9 @@ describe('<bulbs-video> <Revealed>', () => {
         gaTrackerAction,
       });
       playerSetup = sinon.spy();
+      playerOn = sinon.spy();
       player = {
+        on: playerOn,
         setup: playerSetup,
       };
       global.jwplayer = () => {
@@ -679,11 +682,21 @@ describe('<bulbs-video> <Revealed>', () => {
       };
     });
 
+    describe('contstructor', () => {
+      it('binds the forwardJWEvent method', () => {
+        sinon.spy(Revealed.prototype.forwardJWEvent, 'bind');
+        let revealed = new Revealed({});
+        expect(Revealed.prototype.forwardJWEvent.bind).to.have.been.calledWith(revealed);
+        sinon.restore();
+      });
+    });
+
     describe('player set up', () => {
       let sources;
       let extractSourcesStub;
       let vastUrlStub;
       let extractTrackCaptionsStub;
+      let forwardJWEvent = sinon.spy();
 
       context('regular setup', () => {
         beforeEach(() => {
@@ -704,11 +717,16 @@ describe('<bulbs-video> <Revealed>', () => {
             extractSources: extractSourcesStub,
             vastUrl: vastUrlStub,
             extractTrackCaptions: extractTrackCaptionsStub,
+            forwardJWEvent,
           }, element, videoMeta);
         });
 
         it('sets up the player', () => {
           expect(playerSetup.called).to.be.true;
+        });
+
+        it('binds to player complete event', () => {
+          expect(playerOn).to.have.been.calledWith('complete', forwardJWEvent);
         });
 
         it('includes only the HLS & mp4 sources', () => {

--- a/elements/bulbs-video/elements/video-carousel.js
+++ b/elements/bulbs-video/elements/video-carousel.js
@@ -57,7 +57,7 @@ class BulbsVideoCarousel extends BulbsHTMLElement {
       '<bulbs-video-carousel> MUST contain a <bulbs-carousel>'
     );
 
-    this.videoPlayer.addEventListener('ended', this.playerEnded = this.playerEnded.bind(this), true);
+    this.videoPlayer.addEventListener('jw-complete', this.playerEnded = this.playerEnded.bind(this), true);
     this.carousel.addEventListener('click', this.handleClick = this.handleClick.bind(this));
 
     this.state = new VideoCarouselState({

--- a/elements/bulbs-video/elements/video-carousel.test.js
+++ b/elements/bulbs-video/elements/video-carousel.test.js
@@ -72,7 +72,7 @@ describe('<bulbs-video-carousel>', () => {
     it('attaches playerEnded handler to videoPlayer', () => {
       subject.attachedCallback();
       expect(videoPlayer.addEventListener).to.have.been.calledWith(
-        'ended', subject.playerEnded, true
+        'jw-complete', subject.playerEnded, true
       );
     });
 

--- a/lib/bulbs-elements/util/on-ready-or-now.test.js
+++ b/lib/bulbs-elements/util/on-ready-or-now.test.js
@@ -1,4 +1,4 @@
-import onReadyOrNow './on-ready-or-now';
+import onReadyOrNow from './on-ready-or-now';
 
 describe('onReadyOrNow', () => {
   let sandbox = sinon.sandbox.create();
@@ -14,10 +14,9 @@ describe('onReadyOrNow', () => {
 
   it('should callback when the DOMContentLoaded event fires', () => {
     let spy = sandbox.spy();
-    sandbox.stub(onReadyOrNow, 'getDocumentReadyState', () => 'interactive');
+    sandbox.stub(onReadyOrNow, 'getDocumentReadyState', () => 'loading');
     onReadyOrNow(spy);
-    spy.reset();
     window.dispatchEvent(new CustomEvent('DOMContentLoaded'));
-    expect(spy).to.have.been.called;
+    expect(spy).to.have.been.called.once;
   });
 });


### PR DESCRIPTION
fixes a bug where there were two audio tracks playing at once

Also fixes an issue with the video carousel where it skipped ot the next clip when an ad finished, rather than when the video finished

# To Reproduce

Go to: http://www.avclub.com

Play an item in the video carousel. Wait for the ad to finish. The carousel will advance to the next video without playing the one you requested, and there will be multiple audio streams playing on top of each other.

# To Test

Go to: http://fix-double-video.test.avclub.com

Play an item in the video carousel. Wait for the ad to finish. The content should start and only one audio track should play.

Scrub to almost the end of the video and wait for the video to complete. The next item in the carousel should start playing.