### PR TITLE
In view page tracking

### DIFF
--- a/elements/bulbs-dfp/bulbs-dfp.js
+++ b/elements/bulbs-dfp/bulbs-dfp.js
@@ -149,7 +149,7 @@ export default class BulbsDfp extends BulbsHTMLElement {
   }
 
   get isViewable () {
-    return util.InViewMonitor.isElementInViewport(this, {
+    return util.InViewMonitor.isElementInViewport(this, null, {
       distanceFromTop: this.offsetHeight * 0.66,
       distanceFromBottom: -(this.offsetHeight * 0.66),
     });

--- a/elements/bulbs-slideshow/bulbs-slideshow.test.js
+++ b/elements/bulbs-slideshow/bulbs-slideshow.test.js
@@ -8,7 +8,7 @@ describe('<bulbs-slideshow>', () => {
     sandbox = sinon.sandbox.create();
     window.picturefill = sandbox.spy();
     fixture.load('bulbs-slideshow.html');
-    subject = fixture.el.firstChild;
+    subject = fixture.el.querySelector('bulbs-slideshow');
     setImmediate(() => done());
   });
 

--- a/elements/bulbs-video/bulbs-video.test.js
+++ b/elements/bulbs-video/bulbs-video.test.js
@@ -95,18 +95,8 @@ describe('<bulbs-video>', () => {
       props.disableLazyLoading = false;
 
       container = document.createElement('div');
-
-      container.innerHTML = `
-        <div style="
-            position: absolute;
-            top: 200%;
-            left: 0px;
-            display: block;
-            width: 10px;
-            height: 10px;
-          ">
-        </div>
-      `;
+      container.style.position = 'fixed';
+      container.style.top = '200%';
       document.body.appendChild(container);
       setImmediate(() => done());
     });
@@ -120,7 +110,7 @@ describe('<bulbs-video>', () => {
       videoElement.setAttribute('src', src);
       container.appendChild(videoElement);
 
-      container.firstElementChild.style.top = '0';
+      container.style.top = '0';
       try {
         window.dispatchEvent(new Event('scroll'));
       }

--- a/lib/bulbs-elements/util/in-view-monitor.js
+++ b/lib/bulbs-elements/util/in-view-monitor.js
@@ -1,15 +1,40 @@
-const isElementInViewport = (el, options = {}) => {
+const isElementInViewport = (el, rect, options = {}) => {
+  return viewStats(el, rect, options).inView;
+};
+
+const viewStats = (el, rect, options = {}) => {
   if (!document.contains(el)) {
     return false;
   }
 
-  let rect = el.getBoundingClientRect();
+  if (!rect) {
+    rect = el.getBoundingClientRect();
+  }
 
-  return rect.bottom > (options.distanceFromTop || 0) &&
+  let inView = rect.bottom > (options.distanceFromTop || 0) &&
     rect.right > 0 &&
     rect.left < (window.innerWidth || document.documentElement.clientWidth) &&
     rect.top < (window.innerHeight || document.documentElement.clientHeight) + (options.distanceFromBottom || 0)
   ;
+
+  let percentage = 0;
+  let start = 50;
+  let height = Math.abs(Math.floor(rect.height));
+  let top = rect.top;
+
+  if (rect.top <= start && height > 0) {
+    let position = top;
+    if (position < 0) {
+      position = position * -1;
+    }
+    percentage = position / height * 100;
+  }
+  let scrollPercent = Math.min(Math.abs(Math.floor(percentage)), 100);
+
+  return {
+    inView,
+    scrollPercent,
+  };
 };
 
 let inViewId = 0;
@@ -26,7 +51,41 @@ function init () {
 }
 
 const maybeEmitEvent = (monitoredItem) => {
-  let inView = isElementInViewport(monitoredItem.element, monitoredItem.options);
+  let { inView, scrollPercent } = viewStats(
+    monitoredItem.element,
+    monitoredItem.latestRect,
+    monitoredItem.options
+  );
+  let previousScroll = monitoredItem.scrollPercent;
+
+  if (scrollPercent > 0 && previousScroll === 0) {
+    let event = new CustomEvent('pagestart');
+    monitoredItem.element.dispatchEvent(event);
+  }
+  if (scrollPercent < 100 && previousScroll === 100) {
+    let event = new CustomEvent('pagestart');
+    monitoredItem.element.dispatchEvent(event);
+  }
+
+  if (scrollPercent === 100 && previousScroll < 100) {
+    let event = new CustomEvent('pageend');
+    monitoredItem.element.dispatchEvent(event);
+  }
+  if (scrollPercent === 0 && previousScroll > 0) {
+    let event = new CustomEvent('pageend');
+    monitoredItem.element.dispatchEvent(event);
+  }
+
+  if (scrollPercent !== previousScroll) {
+    monitoredItem.scrollPercent = scrollPercent;
+    let event = new CustomEvent('progresschange', {
+      detail: {
+        percent: scrollPercent,
+      },
+    });
+    monitoredItem.element.dispatchEvent(event);
+  }
+
   if (inView && monitoredItem.state === 'out') {
     monitoredItem.state = 'in';
     let event = new CustomEvent('enterviewport');
@@ -39,10 +98,21 @@ const maybeEmitEvent = (monitoredItem) => {
   }
 };
 
+function cacheBoundingClientRect (monitoredItem) {
+  monitoredItem.latestRect = monitoredItem.element.getBoundingClientRect();
+}
+
 function handleDisplayMutation () {
   if (!animationRequest) {
     animationRequest = requestAnimationFrame(() => {
       animationRequest = null;
+      // This optimization gets all rects in one go to prevent
+      // layout thrashing. If layout changes between calls to getBoundingClientRect
+      // it can become a very slow api call.
+      Object.keys(monitoredItems).forEach((key) => {
+        cacheBoundingClientRect(monitoredItems[key]);
+      });
+
       Object.keys(monitoredItems).forEach((key) => {
         maybeEmitEvent(monitoredItems[key]);
       });

--- a/lib/bulbs-elements/util/in-view-monitor.test.js
+++ b/lib/bulbs-elements/util/in-view-monitor.test.js
@@ -190,6 +190,57 @@ describe('InViewMonitor', () => {
     });
   });
 
+  describe.only('progress events', () => {
+    let spy;
+    beforeEach(() => spy = sinon.spy());
+    it('emits progresschange events when the page scrolls', (done) => {
+      el.style.top = '0px';
+      InViewMonitor.add(el);
+      el.addEventListener('progresschange', (event) => {
+        expect(event.detail.percent).to.eql(50);
+        done();
+      });
+      el.style.top = '-5px';
+      InViewMonitor.checkElement(el);
+    });
+
+    it('emits pagestart event when page starts from top', () => {
+      el.style.top = '-10px';
+      InViewMonitor.add(el);
+      el.addEventListener('pagestart', spy);
+      el.style.top = '-5px';
+      InViewMonitor.checkElement(el);
+      expect(spy).to.have.been.called.once;
+    });
+
+    it('emits pagestart event when page starts from bottom', () => {
+      el.style.top = '10px';
+      InViewMonitor.add(el);
+      el.addEventListener('pagestart', spy);
+      el.style.top = '9px';
+      InViewMonitor.checkElement(el);
+      expect(spy).to.have.been.called.once;
+    });
+
+    it('emits pagend event when page ends from top', () => {
+      el.style.top = '-5px';
+      InViewMonitor.add(el);
+      el.addEventListener('pageend', spy);
+      el.style.top = '-10px';
+      InViewMonitor.checkElement(el);
+      expect(spy).to.have.been.called.once;
+    });
+
+    it('emits pageend event when page ends from bottom', () => {
+      el.style.top = '9px';
+      InViewMonitor.add(el);
+      el.addEventListener('pageend', spy);
+      el.style.top = '10px';
+      InViewMonitor.checkElement(el);
+      expect(spy).to.have.been.called.once;
+    });
+  });
+
   describe('distanceFromBottom', () => {
     let spy;
 

--- a/lib/bulbs-elements/util/in-view-monitor.test.js
+++ b/lib/bulbs-elements/util/in-view-monitor.test.js
@@ -190,7 +190,7 @@ describe('InViewMonitor', () => {
     });
   });
 
-  describe.only('progress events', () => {
+  describe('progress events', () => {
     let spy;
     beforeEach(() => spy = sinon.spy());
     it('emits progresschange events when the page scrolls', (done) => {

--- a/lib/bulbs-elements/util/in-view-monitor.test.js
+++ b/lib/bulbs-elements/util/in-view-monitor.test.js
@@ -25,6 +25,7 @@ describe('InViewMonitor', () => {
   });
 
   afterEach(() => {
+    InViewMonitor.remove(el);
     el.remove();
   });
 


### PR DESCRIPTION
This change emits

`progresschange`
`pagestart`
`pageend`

events on elements that are tracked by the `InViewMonitor` utility.

This is used by the `<bulbs-page>` element to determine when to fire analytics events and alter the address bar with the pushstate api.

This duplicates part of the capabilities of the `<bulbs-reading-list>` and it would be wise to migrate the reading list to use `InViewMonitor` for these events. `InViewMonitor` batches calls to `getBoundingClientRect` which prevents inefficient 'layout thrashing'