### PR TITLE
Tests for scroll locking

### DIFF
--- a/elements/bulbs-dfp/bulbs-dfp.test.js
+++ b/elements/bulbs-dfp/bulbs-dfp.test.js
@@ -241,9 +241,10 @@ describe('<div is="bulbs-dfp">', () => {
     beforeEach((done) => {
       element.style.height = '100px';
       element.style.width = '100px';
-      element.style.position = 'absolute';
+      element.style.position = 'fixed';
       element.style.background = 'black';
-      element.style.left = '0px';
+      element.style.top = '0';
+      element.style.left = '0';
       document.body.appendChild(element);
       setImmediate(() => done());
     });
@@ -259,11 +260,13 @@ describe('<div is="bulbs-dfp">', () => {
     });
 
     it('is false when > 2/3s below bottom of viewport', () => {
+      element.style.top = '';
       element.style.bottom = '-34px';
       expect(element.isViewable).to.be.false;
     });
 
     it('is true when < 2/3s below bottom of viewport', () => {
+      element.style.top = '';
       element.style.bottom = '-33px';
       expect(element.isViewable).to.be.true;
     });

--- a/karma.devicelab.js
+++ b/karma.devicelab.js
@@ -67,7 +67,7 @@ karmaConfig.customLaunchers = {
   bs_safari_9: {
     base: 'BrowserStack',
     os: 'osx',
-    os_version: 'yosemite',
+    os_version: 'elcapitan',
     browser: 'safari',
     browser_version: '9.1',
   },

--- a/karma.devicelab.js
+++ b/karma.devicelab.js
@@ -69,7 +69,7 @@ karmaConfig.customLaunchers = {
     os: 'osx',
     os_version: 'yosemite',
     browser: 'safari',
-    browser_version: '9',
+    browser_version: '9.1',
   },
   bs_chrome_50: {
     base: 'BrowserStack',

--- a/lib/bulbs-elements/util/index.js
+++ b/lib/bulbs-elements/util/index.js
@@ -2,6 +2,7 @@ import Human from './human';
 import InViewMonitor from './in-view-monitor';
 import LockScroll from './lock-scroll';
 import copyAttribute from './copy-attribute';
+import detectAdBlock from './detect-ad-block';
 import filterBadResponse from './filter-bad-response';
 import getAnalyticsManager from './get-analytics-manager';
 import getResponseJSON from './get-response-json';
@@ -11,7 +12,7 @@ import makeRequest from './make-request';
 import moveChildren from './move-children';
 import onReadyOrNow from './on-ready-or-now';
 import prepGaEventTracker from './prep-ga-event-tracker';
-import detectAdBlock from './detect-ad-block';
+import scrollingElement from './scrolling-element';
 import supportsCalcInTransform from './supports-calc-in-transform';
 
 module.exports = {
@@ -19,6 +20,7 @@ module.exports = {
   InViewMonitor,
   LockScroll,
   copyAttribute,
+  detectAdBlock,
   filterBadResponse,
   getAnalyticsManager,
   getResponseJSON,
@@ -28,6 +30,6 @@ module.exports = {
   moveChildren,
   onReadyOrNow,
   prepGaEventTracker,
+  scrollingElement,
   supportsCalcInTransform,
-  detectAdBlock,
 };

--- a/lib/bulbs-elements/util/index.js
+++ b/lib/bulbs-elements/util/index.js
@@ -1,5 +1,6 @@
 import Human from './human';
 import InViewMonitor from './in-view-monitor';
+import LockScroll from './lock-scroll';
 import copyAttribute from './copy-attribute';
 import filterBadResponse from './filter-bad-response';
 import getAnalyticsManager from './get-analytics-manager';
@@ -15,6 +16,7 @@ import supportsCalcInTransform from './supports-calc-in-transform';
 module.exports = {
   Human,
   InViewMonitor,
+  LockScroll,
   copyAttribute,
   filterBadResponse,
   getAnalyticsManager,

--- a/lib/bulbs-elements/util/lock-scroll.js
+++ b/lib/bulbs-elements/util/lock-scroll.js
@@ -9,6 +9,7 @@
  */
 
 import Human from './human';
+import scrollingElement from './scrolling-element';
 
 let state = {};
 let LockScroll = {};
@@ -31,7 +32,7 @@ function animationLoop (element) {
       else {
         offset = 0;
       }
-      element.offsetParent.scrollTop = element.offsetTop + offset;
+      scrollingElement.scrollTop = element.offsetTop + offset;
     }
     catch (error) {
       console.warn(error);

--- a/lib/bulbs-elements/util/lock-scroll.js
+++ b/lib/bulbs-elements/util/lock-scroll.js
@@ -1,0 +1,64 @@
+/* This module locks the page scroll to a specific element.
+ * This is useful for pages that use the pushState api.
+ * When we come in on a URL we want to scroll to the content connected to that URL.
+ * But images and other widgets will continue to load in and alter the page height.
+ *
+ * This module uses a requestAnimationFrame loop to keep the scroll position
+ * locked to one element. it respects Human input and ends the loop once we have
+ * detected Human interaction with the browser
+ */
+
+import Human from './human';
+
+let state = {};
+let LockScroll = {};
+
+// eslint-disable-next-line consistent-return
+function animationLoop (element) {
+  let offset;
+  let selector;
+  let offsetElement;
+
+  if (!Human.hasInteracted) {
+    try {
+      offset;
+      selector = element.getAttribute('scroll-offset-selector');
+      offsetElement;
+      offsetElement = document.querySelector(selector);
+      if (offsetElement) {
+        offset = offsetElement.offsetHeight;
+      }
+      else {
+        offset = 0;
+      }
+      element.offsetParent.scrollTop = element.offsetTop + offset;
+    }
+    catch (error) {
+      console.warn(error);
+    }
+    return requestAnimationFrame(LockScroll.animationLoop.bind(null, element));
+  }
+}
+
+Object.assign(LockScroll, {
+  lockToElement (element) {
+    if (state.lockedElement) {
+      console.warn(`
+        Attempted to lock scroll to more than one element. Only one element can be
+        the subject of scroll locking at a time. Original target is:
+      `, state.lockedElement, 'The second target is:', element);
+    }
+    else {
+      state.lockedElement = element;
+      LockScroll.animationLoop(element);
+    }
+  },
+
+  resetState () {
+    delete state.lockedElement;
+  },
+
+  animationLoop,
+});
+
+export default LockScroll;

--- a/lib/bulbs-elements/util/lock-scroll.test.js
+++ b/lib/bulbs-elements/util/lock-scroll.test.js
@@ -2,6 +2,7 @@
 
 import LockScroll from './lock-scroll';
 import Human from './human';
+import scrollingElement from './scrolling-element';
 
 describe('LockScroll', () => {
   let sandbox;
@@ -21,7 +22,7 @@ describe('LockScroll', () => {
     spacer.style.height = '400px';
     document.body.prepend(spacer);
 
-    document.body.style.minHeight = '4000px';
+    document.body.style.height = '4000px';
 
     offset = document.createElement('div');
     offset.setAttribute('id', 'offset');
@@ -35,7 +36,7 @@ describe('LockScroll', () => {
     element.remove();
     spacer.remove();
     offset.remove();
-    document.body.style.minHeight = '';
+    document.body.style.height = '';
   });
 
   context('Human.hasInteracted is true', () => {
@@ -49,17 +50,17 @@ describe('LockScroll', () => {
   context('Human.hasInteracted is false', () => {
     beforeEach(() => Human.hasInteracted = false);
 
-    it('sets element.offsetParent.scrollTop to element.offsetTop', () => {
+    it('sets scrollingElement.scrollTop to element.offsetTop', () => {
       let animationFrameRequested = LockScroll.animationLoop(element);
       cancelAnimationFrame(animationFrameRequested);
-      expect(element.offsetParent.scrollTop).to.eql(400);
+      expect(scrollingElement.scrollTop).to.eql(400);
     });
 
     it('adds an offset based on a scroll-offset-selector attribute', () => {
       element.setAttribute('scroll-offset-selector', '#offset');
       let animationFrameRequested = LockScroll.animationLoop(element);
       cancelAnimationFrame(animationFrameRequested);
-      expect(element.offsetParent.scrollTop).to.eql(450);
+      expect(scrollingElement.scrollTop).to.eql(450);
     });
   });
 });

--- a/lib/bulbs-elements/util/lock-scroll.test.js
+++ b/lib/bulbs-elements/util/lock-scroll.test.js
@@ -1,0 +1,65 @@
+/* eslint-disable no-return-assign */
+
+import LockScroll from './lock-scroll';
+import Human from './human';
+
+describe('LockScroll', () => {
+  let sandbox;
+  let element;
+  let spacer;
+  let offset;
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+    sandbox.spy(LockScroll, 'animationLoop');
+
+    element = document.createElement('div');
+    element.style.height = '400px';
+    document.body.prepend(element);
+
+    spacer = document.createElement('div');
+    spacer.style.height = '400px';
+    document.body.prepend(spacer);
+
+    document.body.style.minHeight = '4000px';
+
+    offset = document.createElement('div');
+    offset.setAttribute('id', 'offset');
+    offset.style.height = '50px';
+    document.body.append(offset);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    LockScroll.resetState();
+    element.remove();
+    spacer.remove();
+    offset.remove();
+    document.body.style.minHeight = '';
+  });
+
+  context('Human.hasInteracted is true', () => {
+    beforeEach(() => Human.hasInteracted = true);
+
+    it('does nothing', () => {
+      expect(LockScroll.animationLoop).not.to.have.been.called;
+    });
+  });
+
+  context('Human.hasInteracted is false', () => {
+    beforeEach(() => Human.hasInteracted = false);
+
+    it('sets element.offsetParent.scrollTop to element.offsetTop', () => {
+      let animationFrameRequested = LockScroll.animationLoop(element);
+      cancelAnimationFrame(animationFrameRequested);
+      expect(element.offsetParent.scrollTop).to.eql(400);
+    });
+
+    it('adds an offset based on a scroll-offset-selector attribute', () => {
+      element.setAttribute('scroll-offset-selector', '#offset');
+      let animationFrameRequested = LockScroll.animationLoop(element);
+      cancelAnimationFrame(animationFrameRequested);
+      expect(element.offsetParent.scrollTop).to.eql(450);
+    });
+  });
+});

--- a/lib/bulbs-elements/util/scrolling-element.js
+++ b/lib/bulbs-elements/util/scrolling-element.js
@@ -1,0 +1,1 @@
+export default document.scrollingElement || document.documentElement;

--- a/scripts/ci
+++ b/scripts/ci
@@ -3,10 +3,10 @@ set -e
 
 # List of browsers to test
 BROWSERS=(
-    bs_chrome_50
-    bs_firefox_47
     bs_safari_9
     bs_ie_11
+    bs_firefox_47
+    bs_chrome_50
 )
 
 for B in ${BROWSERS[@]}; do


### PR DESCRIPTION
This adds a utility that locks the scroll position to a given element.

`util.ScrollLock.lockToElement`

It stops locking scroll position when the user interacts with the browser, by scrolling, typing, touching, etc.

It adjust the scroll position on every animation frame, this mitigates the content-reflow that would otherwise bump the scroll position.

@kand @MelizzaP @spra85 