### PR TITLE
Make rail player auto play videos

### DIFF
--- a/elements/bulbs-video/elements/rail-player/rail-player.js
+++ b/elements/bulbs-video/elements/rail-player/rail-player.js
@@ -18,6 +18,7 @@ export default class RailPlayer extends BulbsElement {
   componentDidMount () {
     detectAdBlock((isAdBlocked) => {
       this.isAdBlocked = isAdBlocked;
+      this.store.actions.revealPlayer();
       this.fetchVideo();
     });
   }


### PR DESCRIPTION
Rail player is no longer auto playing videos. Adding this back in. 

@collin @spra85 

Example here:

https://github.com/theonion/omni/pull/365