### PR TITLE
Lazy load ads

### DIFF
--- a/elements/bulbs-dfp/bulbs-dfp.js
+++ b/elements/bulbs-dfp/bulbs-dfp.js
@@ -68,13 +68,12 @@ export default class BulbsDfp extends BulbsHTMLElement {
     let browserVisibility = document.visibilityState;
 
     if (this.isViewable) {
-      util.getAnalyticsManager().sendEvent({
-        eventCategory: 'bulbs-dfp-element Live Metrics',
-        eventAction: `30-second-refresh-triggered-${browserVisibility}`,
-        eventLabel: this.dataset.adUnit,
-      });
-
       if (browserVisibility === 'visible') {
+        util.getAnalyticsManager().sendEvent({
+          eventCategory: 'bulbs-dfp-element Live Metrics',
+          eventAction: '30-second-refresh-triggered-visible',
+          eventLabel: this.dataset.adUnit,
+        });
         this.adsManager.reloadAds(this);
         this.adsManager.refreshSlot(this);
       }

--- a/elements/bulbs-dfp/bulbs-dfp.js
+++ b/elements/bulbs-dfp/bulbs-dfp.js
@@ -35,10 +35,10 @@ export default class BulbsDfp extends BulbsHTMLElement {
     let threshold = parseFloat(this.getAttribute('viewport-threshold'), 10);
     util.InViewMonitor.add(this, {
       get distanceFromTop () {
-        return window.innerHeight * threshold;
+        return -(window.innerHeight * threshold);
       },
       get distanceFromBottom () {
-        return -(window.innerHeight * threshold);
+        return window.innerHeight * threshold;
       },
     });
 
@@ -69,16 +69,8 @@ export default class BulbsDfp extends BulbsHTMLElement {
         eventAction: 'enterviewport',
         eventLabel: this.dataset.adUnit,
       });
+      this.adsManager.refreshSlot(this);
     }
-    /* We are taking our time rolling out this change.
-     *  1) we want to make sure the page-speed implications of putting
-     *      bulbs-elements in the critical path for ad loading isn't too heavy
-     *  2) we want to look at analytics to get some idea of how often this will
-     *      happen.
-     *
-     * The eventual strategy will be:
-    this.adsManager.loadAds(this)
-     */
   }
 
   handleExitViewport () {
@@ -144,6 +136,7 @@ export default class BulbsDfp extends BulbsHTMLElement {
 
       if (browserVisibility === 'visible') {
         this.adsManager.reloadAds(this);
+        this.adsManager.refreshSlot(this);
       }
     }
   }

--- a/elements/bulbs-dfp/bulbs-dfp.test.js
+++ b/elements/bulbs-dfp/bulbs-dfp.test.js
@@ -8,6 +8,7 @@ describe('<div is="bulbs-dfp">', () => {
   let sandbox;
   let sendEventSpy;
   let reloadAdsSpy;
+  let refreshSlotSpy;
 
   beforeEach((done) => {
     sandbox = sinon.sandbox.create();
@@ -21,12 +22,14 @@ describe('<div is="bulbs-dfp">', () => {
     sandbox.stub(util.InViewMonitor, 'remove');
     sendEventSpy = sandbox.spy();
     reloadAdsSpy = sandbox.spy();
+    refreshSlotSpy = sandbox.spy();
     sandbox.stub(util, 'getAnalyticsManager', () => {
       return { sendEvent: sendEventSpy };
     });
 
     window.BULBS_ELEMENTS_ADS_MANAGER = {
       reloadAds: reloadAdsSpy,
+      refreshSlot: refreshSlotSpy,
       adUnits: {
         units: {},
       },
@@ -77,8 +80,8 @@ describe('<div is="bulbs-dfp">', () => {
     it('adds self to InViewMonitor', () => {
       element.attachedCallback();
       expect(util.InViewMonitor.add).to.have.been.calledWith(element, {
-        distanceFromTop: window.innerHeight,
-        distanceFromBottom: -window.innerHeight,
+        distanceFromTop: -window.innerHeight,
+        distanceFromBottom: window.innerHeight,
       });
     });
 
@@ -147,6 +150,7 @@ describe('<div is="bulbs-dfp">', () => {
         eventAction: 'enterviewport',
         eventLabel: adUnitName,
       }).once;
+      expect(refreshSlotSpy).to.have.been.calledWith(element);
     });
   });
 
@@ -222,6 +226,11 @@ describe('<div is="bulbs-dfp">', () => {
       it('reloads ads', () => {
         element.handleInterval();
         expect(reloadAdsSpy).to.have.been.calledWith(element).once;
+      });
+
+      it('refreshes the slot', () => {
+        element.handleInterval();
+        expect(refreshSlotSpy).to.have.been.calledWith(element);
       });
     });
 

--- a/elements/bulbs-video/elements/rail-player/rail-player.test.js
+++ b/elements/bulbs-video/elements/rail-player/rail-player.test.js
@@ -48,7 +48,8 @@ describe('<rail-player>', () => {
         sinon.spy(subject.store.actions, 'fetchVideo');
         subject.isAdBlocked = true;
         subject.fetchVideo();
-        expect(subject.store.actions.fetchVideo).to.have.been.calledWith('http://example.org/a-src?ad_block_active=true');
+        expect(subject.store.actions.fetchVideo)
+          .to.have.been.calledWith('http://example.org/a-src?ad_block_active=true');
       });
       it('checks if ad block is disabled', () => {
         sinon.spy(subject.store.actions, 'fetchVideo');

--- a/elements/campaign-display/campaign-display.js
+++ b/elements/campaign-display/campaign-display.js
@@ -3,7 +3,6 @@ import invariant from 'invariant';
 
 import BulbsElement from 'bulbs-elements/bulbs-element';
 import { registerReactElement } from 'bulbs-elements/register';
-import { loadOnDemand } from 'bulbs-elements/util';
 
 import './campaign-display.scss';
 
@@ -62,7 +61,7 @@ Object.assign(CampaignDisplay, {
   },
 });
 
-registerReactElement('campaign-display', loadOnDemand(CampaignDisplay));
+registerReactElement('campaign-display', CampaignDisplay);
 
 export default CampaignDisplay;
 export const displayPropType = CampaignDisplay.propTypes.display;

--- a/elements/campaign-display/campaign-display.js
+++ b/elements/campaign-display/campaign-display.js
@@ -3,6 +3,7 @@ import invariant from 'invariant';
 
 import BulbsElement from 'bulbs-elements/bulbs-element';
 import { registerReactElement } from 'bulbs-elements/register';
+import { loadOnDemand } from 'bulbs-elements/util';
 
 import './campaign-display.scss';
 
@@ -61,7 +62,7 @@ Object.assign(CampaignDisplay, {
   },
 });
 
-registerReactElement('campaign-display', CampaignDisplay);
+registerReactElement('campaign-display', loadOnDemand(CampaignDisplay));
 
 export default CampaignDisplay;
 export const displayPropType = CampaignDisplay.propTypes.display;


### PR DESCRIPTION
This change is coupled with the updates to the ads manager here (https://github.com/theonion/bulbs-public-ads-manager/pull/20) and makes the call to refresh the ad slot using the new method exposed by the ads manager PR.

Test link below (http://lazy-load-ads.test.clickhole.com), items for regression test: 
- Homepage ads
- Campaign pixels
- Article ads
- `inread` ads in article body

