### PR TITLE
Removing a lot of the event chatter to measure refresh/viewport check

### DIFF
--- a/elements/bulbs-dfp/bulbs-dfp.js
+++ b/elements/bulbs-dfp/bulbs-dfp.js
@@ -13,24 +13,12 @@ export default class BulbsDfp extends BulbsHTMLElement {
         'This value defines how many screens away from the viewport the slot ' +
         'will be in order to trigger an ad load. 1.2 = 120% viewport height.');
 
-    util.getAnalyticsManager().sendEvent({
-      eventCategory: 'bulbs-dfp-element Metrics',
-      eventAction: 'attached',
-      eventLabel: this.dataset.adUnit,
-    });
-
     this.handleEnterViewport = this.handleEnterViewport.bind(this);
     this.handleExitViewport = this.handleExitViewport.bind(this);
     this.handleInterval = this.handleInterval.bind(this);
-    this.handleSlotRenderEnded = this.handleSlotRenderEnded.bind(this);
-    this.handleImpressionViewable = this.handleImpressionViewable.bind(this);
-    this.handleSlotOnload = this.handleSlotOnload.bind(this);
 
     this.addEventListener('enterviewport', this.handleEnterViewport);
     this.addEventListener('exitviewport', this.handleExitViewport);
-    this.addEventListener('dfpSlotRenderEnded', this.handleSlotRenderEnded);
-    this.addEventListener('dfpImpressionViewable', this.handleImpressionViewable);
-    this.addEventListener('dfpSlotOnload', this.handleSlotOnload);
 
     let threshold = parseFloat(this.getAttribute('viewport-threshold'), 10);
     util.InViewMonitor.add(this, {
@@ -64,76 +52,21 @@ export default class BulbsDfp extends BulbsHTMLElement {
   handleEnterViewport () {
     if(!this.trackedEnterViewport) {
       this.trackedEnterViewport = true;
-      util.getAnalyticsManager().sendEvent({
-        eventCategory: 'bulbs-dfp-element Metrics',
-        eventAction: 'enterviewport',
-        eventLabel: this.dataset.adUnit,
-      });
+      // * The eventual strategy will be:
+      // this.adsManager.loadAds(this)
     }
-    /* We are taking our time rolling out this change.
-     *  1) we want to make sure the page-speed implications of putting
-     *      bulbs-elements in the critical path for ad loading isn't too heavy
-     *  2) we want to look at analytics to get some idea of how often this will
-     *      happen.
-     *
-     * The eventual strategy will be:
-    this.adsManager.loadAds(this)
-     */
   }
 
   handleExitViewport () {
     if(!this.trackedExitViewport) {
       this.trackedExitViewport = true;
-      util.getAnalyticsManager().sendEvent({
-        eventCategory: 'bulbs-dfp-element Metrics',
-        eventAction: 'exitviewport',
-        eventLabel: this.dataset.adUnit,
-      });
+      // * The eventual strategy will be:
+      //this.adsManager.unloadAds(this)
     }
-
-    /* We are taking our time rolling out this change.
-     *  1) we want to make sure the page-speed implications of putting
-     *      bulbs-elements in the critical path for ad loading isn't too heavy
-     *  2) we want to look at analytics to get some idea of how often this will
-     *      happen.
-     *
-     * The eventual strategy will be:
-    this.adsManager.unloadAds(this)
-     */
-  }
-
-  handleSlotRenderEnded () {
-    util.getAnalyticsManager().sendEvent({
-      eventCategory: 'bulbs-dfp-element Metrics',
-      eventAction: 'slotrenderended',
-      eventLabel: this.dataset.adUnit,
-    });
-  }
-
-  handleImpressionViewable () {
-    util.getAnalyticsManager().sendEvent({
-      eventCategory: 'bulbs-dfp-element Metrics',
-      eventAction: 'impressionviewable',
-      eventLabel: this.dataset.adUnit,
-    });
-  }
-
-  handleSlotOnload () {
-    util.getAnalyticsManager().sendEvent({
-      eventCategory: 'bulbs-dfp-element Metrics',
-      eventAction: 'slotonload',
-      eventLabel: this.dataset.adUnit,
-    });
   }
 
   handleInterval () {
     let browserVisibility = document.visibilityState;
-
-    util.getAnalyticsManager().sendEvent({
-      eventCategory: 'bulbs-dfp-element Live Metrics',
-      eventAction: `30-second-refresh-candidate-${browserVisibility}`,
-      eventLabel: this.dataset.adUnit,
-    });
 
     if (this.isViewable) {
       util.getAnalyticsManager().sendEvent({

--- a/elements/bulbs-dfp/bulbs-dfp.test.js
+++ b/elements/bulbs-dfp/bulbs-dfp.test.js
@@ -55,15 +55,6 @@ describe('<div is="bulbs-dfp">', () => {
       );
     });
 
-    it('sends an attached bulbs-dfp-element Metric', () => {
-      element.attachedCallback();
-      expect(sendEventSpy).to.have.been.calledWith({
-        eventCategory: 'bulbs-dfp-element Metrics',
-        eventAction: 'attached',
-        eventLabel: adUnitName,
-      });
-    });
-
     it('attaches enterviewport listener', () => {
       element.attachedCallback();
       expect(element.addEventListener).to.have.been.calledWith('enterviewport', element.handleEnterViewport);
@@ -107,22 +98,6 @@ describe('<div is="bulbs-dfp">', () => {
 
       expect(window.setInterval).to.have.been.calledWith(element.handleInterval, defaultRefreshInterval);
     });
-
-    it('attaches a dfpSlotRenderEnded event', () => {
-      element.attachedCallback();
-      expect(element.addEventListener).to.have.been.calledWith('dfpSlotRenderEnded', element.handleSlotRenderEnded);
-    });
-
-    it('attaches a dfpImpressionViewabl event', () => {
-      element.attachedCallback();
-      expect(element.addEventListener).to.have.been
-        .calledWith('dfpImpressionViewable', element.handleImpressionViewable);
-    });
-
-    it('attaches a dfpSlotOnload event', () => {
-      element.attachedCallback();
-      expect(element.addEventListener).to.have.been.calledWith('dfpSlotOnload', element.handleSlotOnload);
-    });
   });
 
   describe('detachedCallback', () => {
@@ -139,71 +114,17 @@ describe('<div is="bulbs-dfp">', () => {
   });
 
   describe('handleEnterViewport', () => {
-    it('sends an enterviewport bulbs-dfp-element Metric', () => {
-      element.handleEnterViewport();
-      element.handleEnterViewport();
-      expect(sendEventSpy).to.have.been.calledWith({
-        eventCategory: 'bulbs-dfp-element Metrics',
-        eventAction: 'enterviewport',
-        eventLabel: adUnitName,
-      }).once;
+    xit('will need tests after eventual strategy rolled out', () => {
     });
   });
 
   describe('handleExitViewport', () => {
-    it('sends an exitviewport bulbs-dfp-element Metric', () => {
-      element.handleExitViewport();
-      element.handleExitViewport();
-      expect(sendEventSpy).to.have.been.calledWith({
-        eventCategory: 'bulbs-dfp-element Metrics',
-        eventAction: 'exitviewport',
-        eventLabel: adUnitName,
-      }).once;
-    });
-  });
+    xit('will need tests after eventual strategy rolled out', () => {
 
-  describe('handleSlotRenderEnded', () => {
-    it('sends a slotrendered event', () => {
-      element.handleSlotRenderEnded();
-      expect(sendEventSpy).to.have.been.calledWith({
-        eventCategory: 'bulbs-dfp-element Metrics',
-        eventAction: 'slotrenderended',
-        eventLabel: adUnitName,
-      }).once;
-    });
-  });
-
-  describe('handleImpressionViewable', () => {
-    it('sends an impressionviewable event', () => {
-      element.handleImpressionViewable();
-      expect(sendEventSpy).to.have.been.calledWith({
-        eventCategory: 'bulbs-dfp-element Metrics',
-        eventAction: 'impressionviewable',
-        eventLabel: adUnitName,
-      }).once;
-    });
-  });
-
-  describe('handleSlotOnload', () => {
-    it('sends a slotonload event', () => {
-      element.handleSlotOnload();
-      expect(sendEventSpy).to.have.been.calledWith({
-        eventCategory: 'bulbs-dfp-element Metrics',
-        eventAction: 'slotonload',
-        eventLabel: adUnitName,
-      }).once;
     });
   });
 
   describe('handleInterval', () => {
-    it('sends a 30-second-refresh-candidate bulbs-dfp-element Metric', () => {
-      element.handleInterval();
-      expect(sendEventSpy).to.have.been.calledWith({
-        eventCategory: 'bulbs-dfp-element Live Metrics',
-        eventAction: `30-second-refresh-candidate-${document.visibilityState}`,
-        eventLabel: adUnitName,
-      });
-    });
 
     context('isViewable', () => {
       beforeEach(() => {


### PR DESCRIPTION
This PR removes a lot of the event tracking noise that pushed us over our GA monthly hit allotment last month.  Preserves an event only for when an ad refresh is triggered.

Test link: 
http://less-event-noise.test.theonion.com/