### PR TITLE
restore the ref on the video container

### DIFF
--- a/elements/bulbs-video/components/revealed.js
+++ b/elements/bulbs-video/components/revealed.js
@@ -1,4 +1,5 @@
 // Expose jwplayer on the global context
+//
 // The jwplayer.js file calls window.jwplayer = /* HOT JWPLAYER JS */;
 require('../plugins/jwplayer');
 
@@ -288,6 +289,7 @@ export default class Revealed extends React.Component {
     return (
       <div
         className='bulbs-video-viewport'
+        ref="videoViewport"
         onClick={event => this.handleClick(event)}
         onTouchTap={event => this.handleClick(event)}
       >

--- a/elements/bulbs-video/components/revealed.test.js
+++ b/elements/bulbs-video/components/revealed.test.js
@@ -95,6 +95,12 @@ describe('<bulbs-video> <Revealed>', () => {
       expect(videoContainer).to.have.length(1);
       expect(videoContainer).to.have.className('bulbs-video-video video-container');
     });
+
+    it('specifies refs', () => {
+      subject = (new Revealed(props)).render();
+      expect(subject.ref).to.eql('videoViewport');
+      expect(subject.props.children.ref).to.eql('videoContainer');
+    });
   });
 
   describe('componentDidMount globalsCheck', () => {


### PR DESCRIPTION
@spra85 @MelizzaP @kand 

There was a regression where this ref was lost.