### PR TITLE
Makes sure to call async refresh method instead of refresh in times w…

### DIFF
--- a/elements/bulbs-dfp/bulbs-dfp.js
+++ b/elements/bulbs-dfp/bulbs-dfp.js
@@ -52,7 +52,7 @@ export default class BulbsDfp extends BulbsHTMLElement {
   handleEnterViewport () {
     if(!this.trackedEnterViewport) {
       this.trackedEnterViewport = true;
-      this.adsManager.refreshSlot(this);
+      this.adsManager.asyncRefreshSlot(this);
     }
   }
 

--- a/elements/bulbs-dfp/bulbs-dfp.test.js
+++ b/elements/bulbs-dfp/bulbs-dfp.test.js
@@ -9,6 +9,7 @@ describe('<div is="bulbs-dfp">', () => {
   let sendEventSpy;
   let reloadAdsSpy;
   let refreshSlotSpy;
+  let asyncRefreshSlotSpy;
 
   beforeEach((done) => {
     sandbox = sinon.sandbox.create();
@@ -23,6 +24,7 @@ describe('<div is="bulbs-dfp">', () => {
     sendEventSpy = sandbox.spy();
     reloadAdsSpy = sandbox.spy();
     refreshSlotSpy = sandbox.spy();
+    asyncRefreshSlotSpy = sandbox.spy();
     sandbox.stub(util, 'getAnalyticsManager', () => {
       return { sendEvent: sendEventSpy };
     });
@@ -30,6 +32,7 @@ describe('<div is="bulbs-dfp">', () => {
     window.BULBS_ELEMENTS_ADS_MANAGER = {
       reloadAds: reloadAdsSpy,
       refreshSlot: refreshSlotSpy,
+      asyncRefreshSlot: asyncRefreshSlotSpy,
       adUnits: {
         units: {},
       },
@@ -120,7 +123,7 @@ describe('<div is="bulbs-dfp">', () => {
     it('refreshes the slot', () => {
       element.handleEnterViewport();
       element.handleEnterViewport();
-      expect(refreshSlotSpy).to.have.been.calledWith(element).once;
+      expect(asyncRefreshSlotSpy).to.have.been.calledWith(element).once;
     });
   });
 

--- a/elements/campaign-display/components/dfp-pixel.test.js
+++ b/elements/campaign-display/components/dfp-pixel.test.js
@@ -118,7 +118,7 @@ describe('<campaign-display> <DfpPixel>', () => {
 
     it('should require campaign id', () => {
       renderSubject({ campaignId: undefined }); // eslint-disable-line no-undefined
-      let errorMessagePattern = /Required prop `campaignId` was not specified/;
+      let errorMessagePattern = /prop `campaignId` is marked as required/;
       expect(console.error).to.have.been.calledWithMatch(errorMessagePattern);
     });
   });

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "react-flip-move": "^2.4.0",
     "react-proptypes-url-validator": "0.0.1",
     "react-router": "^1.0.3",
-    "react-tap-event-plugin": "^1.0.0",
+    "react-tap-event-plugin": "^2.0.0",
     "react-transform-catch-errors": "^1.0.1",
     "react-transform-hmr": "^1.0.1",
     "sass-loader": "^3.1.2",


### PR DESCRIPTION
…here the element is attached and in view prior to ad library being api ready

This fixes an issue where the bulbs-dfp element was trying to load an ad before the GPT ad library was ready for it.

Test links: 
http://fix-lazy-load-race-condition.test.theonion.com/
http://fix-lazy-load-race-condition.test.clickhole.com/
http://fix-lazy-load-race-condition.test.avclub.com/