### PR TITLE
allow for a series url prefix in the video meta

### DIFF
--- a/elements/bulbs-video/elements/meta/components/root.js
+++ b/elements/bulbs-video/elements/meta/components/root.js
@@ -8,16 +8,30 @@ export default function VideoMetaRoot (props) {
   }
 
   let seriesElement;
-  let seriesNameElement = <h2 className='bulbs-video-meta-series-name'>
-                    {props.video.series_name || props.video.channel_name}
-                  </h2>;
+  let seriesNameElement = (
+    <h2 className='bulbs-video-meta-series-name'>
+      {props.video.series_name || props.video.channel_name}
+    </h2>
+  );
+
+  let linkUrl;
+  if (props.relativeSeriesLinkPrefix && props.video.series_slug) {
+    linkUrl = `${props.relativeSeriesLinkPrefix}/${props.video.series_slug}`;
+  }
+  else {
+    linkUrl = props.video.series_url || props.video.channel_url;
+  }
 
   if (!props.disableLink) {
-    seriesElement = <a
-            href={props.video.series_url || props.video.channel_url}
-            data-track-action={props.titleTrackAction}
-            data-track-label={props.video.series_name || props.video.channel_name}
-          > {seriesNameElement} </a>;
+    seriesElement = (
+      <a
+        href={linkUrl}
+        data-track-action={props.titleTrackAction}
+        data-track-label={props.video.series_name || props.video.channel_name}
+      >
+       { seriesNameElement }
+      </a>
+    );
   }
   else {
     seriesElement = seriesNameElement;
@@ -52,6 +66,7 @@ VideoMetaRoot.propTypes = {
   campaignUrl: PropTypes.string,
   disableLink: PropTypes.bool,
   mobileTitle: PropTypes.string,
+  relativeSeriesLinkPrefix: PropTypes.string,
   titleTrackAction: PropTypes.string,
   video: PropTypes.object,
 };

--- a/elements/bulbs-video/elements/meta/components/root.test.js
+++ b/elements/bulbs-video/elements/meta/components/root.test.js
@@ -29,6 +29,42 @@ describe('<bulbs-video-meta> <VideoMetaRoot>', () => {
     });
   });
 
+  context('with relativeSeriesLinkPrefix', () => {
+    let _video;
+    beforeEach(() => {
+      props.relativeSeriesLinkPrefix = '/prefix';
+    });
+
+    context('video has series slug', () => {
+      beforeEach(() => {
+        _video = Object.assign({}, video);
+        _video.series_slug = 'cool-series';
+        subject = shallow(<VideoMetaRoot {...props} video={_video}/>);
+      });
+
+      it('constructs prefixed url', () => {
+        expect(subject.find('a').first()).to.have.attr(
+          'href', '/prefix/cool-series'
+        );
+      });
+    });
+
+    context('video has no series slug', () => {
+      beforeEach(() => {
+        _video = Object.assign({}, video);
+        _video.series_slug = null;
+        _video.series_url = '//example.org/video.json';
+        subject = shallow(<VideoMetaRoot {...props} video={_video}/>);
+      });
+
+      it('does not construct prefixed url', () => {
+        expect(subject.find('a').first()).to.have.attr(
+          'href', '//example.org/video.json'
+        );
+      });
+    });
+  });
+
   context('with a video', () => {
     beforeEach(() => {
       subject = shallow(<VideoMetaRoot {...props} video={video}/>);

--- a/elements/bulbs-video/elements/meta/meta.js
+++ b/elements/bulbs-video/elements/meta/meta.js
@@ -16,16 +16,19 @@ export default class VideoMeta extends BulbsElement {
 
   componentDidUpdate (prevProps) {
     if (this.props.src !== prevProps.src) {
-      this.store.actions.setVideoField(null); // eslint-disable-line no-undefined
+      this.store.actions.setVideoField(null);
       this.store.actions.fetchVideo(this.props.src);
     }
   }
 
   render () {
-    return <VideoMetaRoot
-              {...this.props}
-              disableLink={typeof this.props.disableMetaLink === 'string'}
-              video={this.state.video}/>;
+    return (
+      <VideoMetaRoot
+        {...this.props}
+        disableLink={typeof this.props.disableMetaLink === 'string'}
+        video={this.state.video}
+      />
+    );
   }
 }
 
@@ -41,6 +44,7 @@ Object.assign(VideoMeta, {
     campaignTrackAction: PropTypes.string,
     campaignUrl: PropTypes.string,
     disableMetaLink: PropTypes.string,
+    relativeSeriesLinkPrefix: PropTypes.string,
     titleTrackAction: PropTypes.string,
   },
 });


### PR DESCRIPTION
This is a compromise to get us around a sticky situation. Our properties don't have full video data at time of page render.  This leads us to do quite a bit of json fetching from onionstudios to complete that data on the front end.

The video json data has a series url that points to onionstudios.com.

Now our properties are starting to host their own series pages. But that url isn't available in the video meta element.

We're letting the property define the url prefix that is to be mashed together with the series slug.

@kand @spra85 (@mparent61 getting you in here because we discussed this previously)

This will be used as:

```html
<bulbs-video-meta relative-series-link-prefix="/series">
```