### PR TITLE
Do not request campaign-pixel ad slot if the campaign is inactive

### DIFF
--- a/elements/campaign-display/components/campaign-display-root.js
+++ b/elements/campaign-display/components/campaign-display-root.js
@@ -19,7 +19,7 @@ class CampaignDisplayRoot extends Component {
   }
 
   pixelComponent () {
-    if (this.props.noPixel) {
+    if (this.props.noPixel || !this.props.campaign.active) {
       return '';
     }
 

--- a/elements/campaign-display/components/campaign-display-root.test.js
+++ b/elements/campaign-display/components/campaign-display-root.test.js
@@ -209,6 +209,12 @@ describe('<campaign-display> <CampaignDisplayRoot>', () => {
       subject = shallow(<CampaignDisplayRoot {...props} />);
       expect(subject).to.not.be.blank();
     });
+
+    it('does not render a DFP Pixel', () => {
+      props.campaign.active = false;
+      subject = shallow(<CampaignDisplayRoot {...props} />);
+      expect(subject).not.to.have.descendants(DfpPixel);
+    });
   });
 
   context('with no-pixel set', () => {


### PR DESCRIPTION
Make sure we do not make an ad request for the campaign-pixel if the campaign is inactive

Test link: 
http://no-inactive-dfp-pixel.test.theonion.com/interactive/guide-to-extraterrestrial-life