### PR TITLE
style first carousel item properly on first play

### DIFF
--- a/elements/bulbs-video/components/revealed.js
+++ b/elements/bulbs-video/components/revealed.js
@@ -264,6 +264,7 @@ export default class Revealed extends React.Component {
     Comscore.init(this.player, global.BULBS_ELEMENTS_COMSCORE_ID, videoMeta.player_options.comscore.metadata);
 
     this.player.on('beforePlay', this.setPlaysInline);
+    this.player.on('beforePlay', this.forwardJWEvent);
     this.player.on('complete', this.forwardJWEvent);
   }
 

--- a/elements/bulbs-video/components/revealed.test.js
+++ b/elements/bulbs-video/components/revealed.test.js
@@ -747,6 +747,10 @@ describe('<bulbs-video> <Revealed>', () => {
           expect(playerSetup.called).to.be.true;
         });
 
+        it('forwards player beforePlay event', () => {
+          expect(playerOn).to.have.been.calledWith('beforePlay', forwardJWEvent);
+        });
+
         it('forwards player complete event', () => {
           expect(playerOn).to.have.been.calledWith('complete', forwardJWEvent);
         });

--- a/elements/bulbs-video/elements/video-carousel.js
+++ b/elements/bulbs-video/elements/video-carousel.js
@@ -57,12 +57,24 @@ class BulbsVideoCarousel extends BulbsHTMLElement {
       '<bulbs-video-carousel> MUST contain a <bulbs-carousel>'
     );
 
+    this.videoPlayer.addEventListener('jw-beforePlay', this.firstPlay = this.firstPlay.bind(this), true);
     this.videoPlayer.addEventListener('jw-complete', this.playerEnded = this.playerEnded.bind(this), true);
     this.carousel.addEventListener('click', this.handleClick = this.handleClick.bind(this));
 
     this.state = new VideoCarouselState({
       currentItem: this.querySelector('bulbs-carousel-item'),
     });
+  }
+
+  firstPlay () {
+    let items = this.querySelectorAll('bulbs-carousel-item');
+
+    if (items.length > 0) {
+      this.selectItem(items[0]);
+      this.applyState();
+    }
+
+    this.videoPlayer.removeEventListener('jw-beforePlay', this.firstPlay, true);
   }
 
   playerEnded () {

--- a/elements/bulbs-video/elements/video-carousel.test.js
+++ b/elements/bulbs-video/elements/video-carousel.test.js
@@ -69,6 +69,15 @@ describe('<bulbs-video-carousel>', () => {
   });
 
   describe('attachedCallback', () => {
+    it('attaches firstPlay handler to videoPlayer', () => {
+      subject.attachedCallback();
+      expect(videoPlayer.addEventListener).to.have.been.calledWith(
+        'jw-beforePlay',
+        subject.firstPlay,
+        true
+      );
+    });
+
     it('attaches playerEnded handler to videoPlayer', () => {
       subject.attachedCallback();
       expect(videoPlayer.addEventListener).to.have.been.calledWith(
@@ -80,6 +89,30 @@ describe('<bulbs-video-carousel>', () => {
       subject.attachedCallback();
       expect(carousel.addEventListener).to.have.been.calledWith(
         'click', subject.handleClick
+      );
+    });
+  });
+
+  describe('firstPlay', () => {
+
+    it('selects the first item in the carousel', () => {
+      sinon.spy(subject, 'selectItem');
+      sinon.spy(subject, 'applyState');
+
+      subject.firstPlay();
+
+      expect(subject.selectItem).to.have.been.calledWith(firstItem);
+      expect(subject.applyState).to.have.been.calledOnce;
+    });
+
+    it('removes itself', () => {
+
+      subject.firstPlay();
+
+      expect(videoPlayer.removeEventListener).to.have.been.calledWith(
+        'jw-beforePlay',
+        subject.firstPlay,
+        true
       );
     });
   });


### PR DESCRIPTION
This styles the first item in the carousel properly on first video play.

**Release Type**: _patch_
No major features, only a fix.