### PR TITLE
Do not auto close bulbs-flyout when menu is selected

### DIFF
--- a/elements/bulbs-flyover-menu/bulbs-flyover-menu.js
+++ b/elements/bulbs-flyover-menu/bulbs-flyover-menu.js
@@ -31,7 +31,6 @@ class FlyoverMenu extends BulbsHTMLElement {
   attachedCallback () {
     invariant(this.hasAttribute('menu-name'),
       '<bulbs-flyover-menu> MUST have a `menu-name` attribute;');
-    this.addEventListener('click', this.closeFlyover.bind(this));
   }
 
   openFlyover () {


### PR DESCRIPTION
Hot potato fix here. Currently bulbs-flyover is closing when menu is selected. We removed this when we launched resp header but somehow made it back.  We are transferring the close action to the button element

@collin @MelizzaP @kand @spra85  