### PR TITLE
clickventures must be in viewport to trigger scroll action

### DIFF
--- a/elements/bulbs-clickventure/clickventure.js
+++ b/elements/bulbs-clickventure/clickventure.js
@@ -2,7 +2,7 @@
 import { defaults } from 'lodash';
 import velocity from '!imports?this=>window!velocity-animate';
 import '!imports?this=>window!velocity-animate/velocity.ui';
-import { getAnalyticsManager } from 'bulbs-elements/util';
+import { getAnalyticsManager, InViewMonitor } from 'bulbs-elements/util';
 
 velocity
   .RegisterUI('transition.turnPageIn', {
@@ -132,10 +132,12 @@ export default class Clickventure {
   }
 
   alignWithTop () {
-    velocity(this.element, 'scroll', {
-      duration: this.options.alignmentDuration,
-      offset: this.options.alignmentOffset,
-    });
+    if(InViewMonitor.isElementInViewport(this.element[0])) {
+      velocity(this.element, 'scroll', {
+        duration: this.options.alignmentDuration,
+        offset: this.options.alignmentOffset,
+      });
+    }
   }
 
   getIdFromHash (hash) {


### PR DESCRIPTION
# BUG
clickventures initiate a scroll event on load that interferes with infinite scroll, for example if a user is on an article and the 2nd or 3rd content item in the reading list is a clickventure. Once the clickventure loads in the user will be scrolled to the clickventure. 

# fix
Clickventures will not trigger scroll behavior unless clickventure is in the veiwport

# Testing
link: http://clickventure-fix.test.clickhole.com/clickventure/want-leave-earth-go-colonize-mars-5118

There will be multiple clickventures in the reading list, and there should be no odd scrolling or jumping behavior