### PR TITLE
Taboola on reading list

### DIFF
--- a/elements/bulbs-reading-list/lib/reading-list-article.js
+++ b/elements/bulbs-reading-list/lib/reading-list-article.js
@@ -114,7 +114,7 @@ export default class ReadingListArticle {
     this.element.appendChild(taboolaContainer);
     _taboola.push({
       mode: 'organic-text-links-c',
-      container: this.element.id,
+      container: taboolaContainer.id,
       placement: 'Below Article Text Links',
       target_type: 'mix',
     });

--- a/elements/bulbs-reading-list/lib/reading-list-article.js
+++ b/elements/bulbs-reading-list/lib/reading-list-article.js
@@ -127,7 +127,6 @@ export default class ReadingListArticle {
     } else {
       taboolaItem.article = 'auto';
     }
-    console.log(taboolaItem);
     _taboola.push(taboolaItem);
     _taboola.push({ 
       flush:true 

--- a/elements/bulbs-reading-list/lib/reading-list-article.js
+++ b/elements/bulbs-reading-list/lib/reading-list-article.js
@@ -107,6 +107,7 @@ export default class ReadingListArticle {
   }
 
   setupTaboola () {
+    let taboolaCounter = 0;
     let _taboola = window._taboola || [];
     let taboolaContainer = document.createElement('div');
     taboolaContainer.id = 'taboola-below-article-text-links-' + (new Date()).getTime();
@@ -114,7 +115,7 @@ export default class ReadingListArticle {
     _taboola.push({
       mode: 'organic-text-links-c',
       container: taboolaContainer.id,
-      placement: 'Below Article Text Links',
+      placement: 'Below Article Text Links ' + taboolaCounter++,
       target_type: 'mix',
     });
     let taboolaItem = {

--- a/elements/bulbs-reading-list/lib/reading-list-article.js
+++ b/elements/bulbs-reading-list/lib/reading-list-article.js
@@ -127,6 +127,7 @@ export default class ReadingListArticle {
     } else {
       taboolaItem.article = 'auto';
     }
+    console.log(taboolaItem);
     _taboola.push(taboolaItem);
     _taboola.push({ 
       flush:true 
@@ -197,7 +198,6 @@ export default class ReadingListArticle {
     if (this.startedReading(oldProgress, newProgress)) {
       if (this.href !== window.location.pathname) {
         this.pushToHistory();
-
         if (!this.gaTrackerWrapper) {
           this.gaTrackerWrapper = this.prepGaTracker();
         }

--- a/elements/bulbs-reading-list/lib/reading-list-article.js
+++ b/elements/bulbs-reading-list/lib/reading-list-article.js
@@ -107,30 +107,34 @@ export default class ReadingListArticle {
   }
 
   setupTaboola () {
-    let taboolaCounter = 0;
     let _taboola = window._taboola || [];
     let taboolaContainer = document.createElement('div');
+    taboolaContainer.className = 'taboola-container';
     taboolaContainer.id = 'taboola-below-article-text-links-' + (new Date()).getTime();
     this.element.appendChild(taboolaContainer);
-    _taboola.push({
-      mode: 'organic-text-links-c',
-      container: taboolaContainer.id,
-      placement: 'Below Article Text Links ' + taboolaCounter++,
-      target_type: 'mix',
-    });
-    let taboolaItem = {
-      url: this.element.dataset.href,
-    };
-    if (this.element.dataset.isGraphic) {
-      taboolaItem.photo = 'auto';
-    } else if (this.element.dataset.isVideo) {
-      taboolaItem.video = 'auto';
-    } else {
-      taboolaItem.article = 'auto';
-    }
-    _taboola.push(taboolaItem);
-    _taboola.push({
-      flush: true,
+
+    let items = this.element.getElementsByClassName('taboola-container');
+    Array.from(items).forEach(function (el, index, array) {
+      _taboola.push({
+        mode: 'organic-text-links-c',
+        container: el.id,
+        placement: 'Below Article Text Links',
+        target_type: 'mix',
+      });
+      let taboolaItem = {
+        url: el.dataset.href,
+      };
+      if (el.dataset.isGraphic) {
+        taboolaItem.photo = 'auto';
+      } else if (el.dataset.isVideo) {
+        taboolaItem.video = 'auto';
+      } else {
+        taboolaItem.article = 'auto';
+      }
+      _taboola.push(taboolaItem);
+      _taboola.push({
+        flush: true,
+      });
     });
   }
 

--- a/elements/bulbs-reading-list/lib/reading-list-article.js
+++ b/elements/bulbs-reading-list/lib/reading-list-article.js
@@ -107,7 +107,8 @@ export default class ReadingListArticle {
   }
 
   setupTaboola () {
-    let taboola = window._taboola || [];
+    window._taboola = window._taboola || [];
+    let taboola = window._taboola;
     let taboolaContainer = document.createElement('div');
     taboolaContainer.className = 'taboola-container';
     taboolaContainer.id = 'taboola-below-article-text-links-' + (new Date()).getTime();

--- a/elements/bulbs-reading-list/lib/reading-list-article.js
+++ b/elements/bulbs-reading-list/lib/reading-list-article.js
@@ -107,18 +107,18 @@ export default class ReadingListArticle {
   }
 
   setupTaboola () {
-    window._taboola = window._taboola || [];
-    var taboolaContainer = document.createElement("div");
-    taboolaContainer.id = 'taboola-below-article-text-links-' + (new Date()).getTime()
+    let _taboola = window._taboola || [];
+    let taboolaContainer = document.createElement('div');
+    taboolaContainer.id = 'taboola-below-article-text-links-' + (new Date()).getTime();
     this.element.appendChild(taboolaContainer);
     _taboola.push({
-      mode:'organic-text-links-c', 
+      mode: 'organic-text-links-c',
       container: taboolaContainer.id,
-      placement: 'Below Article Text Links', 
-      target_type: 'mix'
+      placement: 'Below Article Text Links',
+      target_type: 'mix',
     });
-    var taboolaItem = {
-      url: this.element.dataset.href
+    let taboolaItem = {
+      url: this.element.dataset.href,
     };
     if (this.element.dataset.isGraphic) {
       taboolaItem.photo = 'auto';
@@ -128,8 +128,8 @@ export default class ReadingListArticle {
       taboolaItem.article = 'auto';
     }
     _taboola.push(taboolaItem);
-    _taboola.push({ 
-      flush:true 
+    _taboola.push({
+      flush: true,
     });
   }
 

--- a/elements/bulbs-reading-list/lib/reading-list-article.js
+++ b/elements/bulbs-reading-list/lib/reading-list-article.js
@@ -112,29 +112,25 @@ export default class ReadingListArticle {
     taboolaContainer.className = 'taboola-container';
     taboolaContainer.id = 'taboola-below-article-text-links-' + (new Date()).getTime();
     this.element.appendChild(taboolaContainer);
-
-    let items = this.element.getElementsByClassName('taboola-container');
-    Array.from(items).forEach(function (el, index, array) {
-      _taboola.push({
-        mode: 'organic-text-links-c',
-        container: el.id,
-        placement: 'Below Article Text Links',
-        target_type: 'mix',
-      });
-      let taboolaItem = {
-        url: el.dataset.href,
-      };
-      if (el.dataset.isGraphic) {
-        taboolaItem.photo = 'auto';
-      } else if (el.dataset.isVideo) {
-        taboolaItem.video = 'auto';
-      } else {
-        taboolaItem.article = 'auto';
-      }
-      _taboola.push(taboolaItem);
-      _taboola.push({
-        flush: true,
-      });
+    _taboola.push({
+      mode: 'organic-text-links-c',
+      container: this.element.id,
+      placement: 'Below Article Text Links',
+      target_type: 'mix',
+    });
+    let taboolaItem = {
+      url: this.element.dataset.href,
+    };
+    if (this.element.dataset.isGraphic) {
+      taboolaItem.photo = 'auto';
+    } else if (this.element.dataset.isVideo) {
+      taboolaItem.video = 'auto';
+    } else {
+      taboolaItem.article = 'auto';
+    }
+    _taboola.push(taboolaItem);
+    _taboola.push({
+      flush: true,
     });
   }
 

--- a/elements/bulbs-reading-list/lib/reading-list-article.js
+++ b/elements/bulbs-reading-list/lib/reading-list-article.js
@@ -107,12 +107,12 @@ export default class ReadingListArticle {
   }
 
   setupTaboola () {
-    let _taboola = window._taboola || [];
+    let taboola = window._taboola || [];
     let taboolaContainer = document.createElement('div');
     taboolaContainer.className = 'taboola-container';
     taboolaContainer.id = 'taboola-below-article-text-links-' + (new Date()).getTime();
     this.element.appendChild(taboolaContainer);
-    _taboola.push({
+    taboola.push({
       mode: 'organic-text-links-c',
       container: taboolaContainer.id,
       placement: 'Below Article Text Links',
@@ -130,8 +130,8 @@ export default class ReadingListArticle {
     else {
       taboolaItem.article = 'auto';
     }
-    _taboola.push(taboolaItem);
-    _taboola.push({
+    taboola.push(taboolaItem);
+    taboola.push({
       flush: true,
     });
   }

--- a/elements/bulbs-reading-list/lib/reading-list-article.js
+++ b/elements/bulbs-reading-list/lib/reading-list-article.js
@@ -123,9 +123,11 @@ export default class ReadingListArticle {
     };
     if (this.element.dataset.isGraphic) {
       taboolaItem.photo = 'auto';
-    } else if (this.element.dataset.isVideo) {
+    } 
+    else if (this.element.dataset.isVideo) {
       taboolaItem.video = 'auto';
-    } else {
+    } 
+    else {
       taboolaItem.article = 'auto';
     }
     _taboola.push(taboolaItem);

--- a/elements/bulbs-reading-list/lib/reading-list-article.js
+++ b/elements/bulbs-reading-list/lib/reading-list-article.js
@@ -118,7 +118,7 @@ export default class ReadingListArticle {
       target_type: 'mix'
     });
     var taboolaItem = {
-      url: this.element.dataset.absoluteUrl
+      url: this.element.dataset.href
     };
     if (this.element.dataset.isGraphic) {
       taboolaItem.photo = 'auto';
@@ -138,7 +138,6 @@ export default class ReadingListArticle {
     this.setupTaboola();
     this.isLoaded = true;
     this.fetchPending = false;
-    this.element.dataset.loadStatus = 'loaded';
     this.element.dataset.loadStatus = 'loaded';
   }
 

--- a/elements/bulbs-reading-list/lib/reading-list-article.js
+++ b/elements/bulbs-reading-list/lib/reading-list-article.js
@@ -106,10 +106,39 @@ export default class ReadingListArticle {
     this.element.dataset.loadStatus = 'loading';
   }
 
+  setupTaboola () {
+    window._taboola = window._taboola || [];
+    var taboolaContainer = document.createElement("div");
+    taboolaContainer.id = 'taboola-below-article-text-links-' + (new Date()).getTime()
+    this.element.appendChild(taboolaContainer);
+    _taboola.push({
+      mode:'organic-text-links-c', 
+      container: taboolaContainer.id,
+      placement: 'Below Article Text Links', 
+      target_type: 'mix'
+    });
+    var taboolaItem = {
+      url: this.element.dataset.absoluteUrl
+    };
+    if (this.element.dataset.isGraphic) {
+      taboolaItem.photo = 'auto';
+    } else if (this.element.dataset.isVideo) {
+      taboolaItem.video = 'auto';
+    } else {
+      taboolaItem.article = 'auto';
+    }
+    _taboola.push(taboolaItem);
+    _taboola.push({ 
+      flush:true 
+    });
+  }
+
   handleLoadContentComplete (content) {
     this.fillContent(content);
+    this.setupTaboola();
     this.isLoaded = true;
     this.fetchPending = false;
+    this.element.dataset.loadStatus = 'loaded';
     this.element.dataset.loadStatus = 'loaded';
   }
 


### PR DESCRIPTION
Working on getting audience exchange (Taboola) set up on ClickHole via adding it to `bulbs-reading-list`. It's similar to what is [currently](https://github.com/theonion/omni/blob/master/onion/onion/static/javascript/article-list-init.js#L35) set up on Onion.

Currently having a fun time figuring out why it works locally and not on test: http://ch-reading-list-i2.test.clickhole.com/article/spellbinding-we-asked-nature-photographers-describ-5261