### PR TITLE
Revert "include credentials in request for video"

### DIFF
--- a/elements/bulbs-video/fields/video-request.js
+++ b/elements/bulbs-video/fields/video-request.js
@@ -10,7 +10,6 @@ export default {
       if (url) {
         state.requestInFlight = true;
         util.makeRequest(url, {
-          credentials: 'include',
           success (response) {
             store.actions.fetchVideoSuccess(response);
             store.actions.setVideoField(response);


### PR DESCRIPTION
Reverts theonion/bulbs-elements#228

Need to make `credentials` optional, test needs a value, production does not.