### PR TITLE
Fixes a bug where multiple videos would play at once

### DIFF
--- a/elements/bulbs-video/bulbs-video.js
+++ b/elements/bulbs-video/bulbs-video.js
@@ -27,11 +27,11 @@ export default class BulbsVideo extends BulbsElement {
 
   componentDidUpdate (prevProps) {
     if (this.props.src !== prevProps.src) {
+      this.store.actions.resetController();
+      this.store.actions.setVideoField(null); // eslint-disable-line no-undefined
       setImmediate(() => {
         // We have to do this in the next execution context to work around timing
         // issues with jwplayer and tearing down video players
-        this.store.actions.resetController();
-        this.store.actions.setVideoField(null); // eslint-disable-line no-undefined
         this.initialDispatch();
       });
     }

--- a/elements/bulbs-video/bulbs-video.js
+++ b/elements/bulbs-video/bulbs-video.js
@@ -29,7 +29,7 @@ export default class BulbsVideo extends BulbsElement {
     if (this.props.src !== prevProps.src) {
       this.store.actions.resetController();
       this.store.actions.setVideoField(null); // eslint-disable-line no-undefined
-      setImmediate(() => {
+      requestAnimationFrame(() => {
         // We have to do this in the next execution context to work around timing
         // issues with jwplayer and tearing down video players
         this.initialDispatch();


### PR DESCRIPTION
In special coverage carousels, coming in on a sub-url would play two videos at once.

This changes the timing of the URL swap and only one video plays:

# broked

www.theonion.com/special/gaming/video/5117

# fixed

http://sc-video-carousel-bug.test.theonion.com/special/gaming/video/5117