### PR TITLE
Pinned element fix

### DIFF
--- a/elements/bulbs-pinned-element/bulbs-pinned-element.test.js
+++ b/elements/bulbs-pinned-element/bulbs-pinned-element.test.js
@@ -10,6 +10,7 @@ describe('<bulbs-pinned-element>', () => {
 
   function attachSubject () {
     parentElement = document.createElement('parent-element');
+    parentElement.style.display = 'block';
 
     parentElement.appendChild(subject);
 
@@ -125,13 +126,13 @@ describe('<bulbs-pinned-element>', () => {
       });
 
       it('should call scroll up handler when scrolling up', () => {
-        sandbox.stub(subject, 'isScrollingUp').returns(false);
+        sandbox.stub(subject, 'isScrollingUp').returns(true);
         sandbox.stub(subject, 'isInView').returns(true);
 
         subject.positionCar();
         mockRaf.step();
 
-        expect(window.requestAnimationFrame).to.have.been.calledOnce;
+        expect(subject.handleScrollUp).to.have.been.calledOnce;
       });
 
       it('should not call scroll up handler when rail is not in view', () => {
@@ -146,6 +147,7 @@ describe('<bulbs-pinned-element>', () => {
 
       it('should call pinToRailBottom if rail not in view && parent is above viewport', () => {
         sandbox.stub(subject, 'isInView').returns(false);
+        sandbox.stub(subject, 'pinToRailBottom');
 
         subject.parentElement.style.position = 'fixed';
         subject.parentElement.style.top = '-200%';
@@ -156,10 +158,13 @@ describe('<bulbs-pinned-element>', () => {
       });
 
       it('should call resetCarPosition if rail not in view && parent is below viewport', () => {
+        document.body.appendChild(parentElement);
+
         sandbox.stub(subject, 'isInView').returns(false);
+        sandbox.stub(subject, 'resetCarPosition');
 
         subject.parentElement.style.position = 'fixed';
-        subject.parentElement.style.top = '200%';
+        subject.parentElement.style.top = '10000%';
         subject.positionCar();
         mockRaf.step();
 

--- a/elements/bulbs-pinned-element/bulbs-pinned-element.test.js
+++ b/elements/bulbs-pinned-element/bulbs-pinned-element.test.js
@@ -147,8 +147,8 @@ describe('<bulbs-pinned-element>', () => {
       it('should call pinToRailBottom if rail not in view && parent is above viewport', () => {
         sandbox.stub(subject, 'isInView').returns(false);
 
-        subject.parent.position = 'fixed';
-        subject.parent.style.top = '-200%';
+        subject.parentElement.style.position = 'fixed';
+        subject.parentElement.style.top = '-200%';
         subject.positionCar();
         mockRaf.step();
 
@@ -158,8 +158,8 @@ describe('<bulbs-pinned-element>', () => {
       it('should call resetCarPosition if rail not in view && parent is below viewport', () => {
         sandbox.stub(subject, 'isInView').returns(false);
 
-        subject.parent.position = 'fixed';
-        subject.parent.style.top = '200%';
+        subject.parentElement.style.position = 'fixed';
+        subject.parentElement.style.top = '200%';
         subject.positionCar();
         mockRaf.step();
 

--- a/elements/bulbs-pinned-element/bulbs-pinned-element.test.js
+++ b/elements/bulbs-pinned-element/bulbs-pinned-element.test.js
@@ -125,14 +125,13 @@ describe('<bulbs-pinned-element>', () => {
       });
 
       it('should call scroll up handler when scrolling up', () => {
-        sandbox.stub(subject, 'isScrollingDown').returns(false);
+        sandbox.stub(subject, 'isScrollingUp').returns(false);
         sandbox.stub(subject, 'isInView').returns(true);
-        sandbox.stub(window, 'setTimeout').returns(true);
 
         subject.positionCar();
         mockRaf.step();
 
-        expect(window.setTimeout).to.have.been.calledOnce;
+        expect(window.requestAnimationFrame).to.have.been.calledOnce;
       });
 
       it('should not call scroll up handler when rail is not in view', () => {
@@ -143,6 +142,28 @@ describe('<bulbs-pinned-element>', () => {
         mockRaf.step();
 
         expect(subject.handleScrollUp).to.not.have.been.called;
+      });
+
+      it('should call pinToRailBottom if rail not in view && parent is above viewport', () => {
+        sandbox.stub(subject, 'isInView').returns(false);
+
+        subject.parent.position = 'fixed';
+        subject.parent.style.top = '-200%';
+        subject.positionCar();
+        mockRaf.step();
+
+        expect(subject.pinToRailBottom).to.have.been.called;
+      });
+
+      it('should call resetCarPosition if rail not in view && parent is below viewport', () => {
+        sandbox.stub(subject, 'isInView').returns(false);
+
+        subject.parent.position = 'fixed';
+        subject.parent.style.top = '200%';
+        subject.positionCar();
+        mockRaf.step();
+
+        expect(subject.resetCarPosition).to.have.been.called;
       });
 
       it('should ensure rail is the size of the parent less any start height offset', () => {


### PR DESCRIPTION
There were some edge cases around scrolling above/below the pinned element container.

_Breaks if you command+up/command+down rapidly:_
http://staff.clickhole.com/article/social-media-fail-long-john-silvers-just-posted-vi-5388

_should scroll better:_
http://pinned-element-fix.test.clickhole.com/article/social-media-fail-long-john-silvers-just-posted-vi-5388