### PR TITLE
bulbs slideshow followups

### DIFF
--- a/elements/bulbs-slick-slideshow/bulbs-slick-slideshow.js
+++ b/elements/bulbs-slick-slideshow/bulbs-slick-slideshow.js
@@ -3,7 +3,8 @@ import {
   BulbsHTMLElement,
 } from 'bulbs-elements/register';
 import $ from 'jquery';
-import * as slick from 'slick-carousel'; // eslint-disable-line
+import * as slick from 'slick-carousel';
+import { InViewMonitor } from 'bulbs-elements/util';
 
 import './bulbs-slick-slideshow.scss';
 
@@ -17,7 +18,7 @@ import './bulbs-slick-slideshow.scss';
 /// 7. On l/r keydown, trigger slidechange.
 class BulbsSlickSlideshow extends BulbsHTMLElement {
   attachedCallback () {
-    this.slideshow = $('.slider');
+    this.slideshow = $(this).find('.slider');
 
     // set variables
     this.initialSlide = 0;
@@ -87,11 +88,17 @@ class BulbsSlickSlideshow extends BulbsHTMLElement {
     this.slideshow.slick('slickGoTo', 0);
   }
 
+  isInViewport () {
+    return InViewMonitor.isElementInViewport(this.slideshow[0]);
+  }
+
   bodyKeyDown (event) {
-    if(event.keyCode === 37) { // left
+    const isVisible = this.isInViewport();
+
+    if(event.keyCode === 37 && isVisible) { // left
       this.slideshow.slick('slickPrev');
     }
-    else if(event.keyCode === 39) { // right
+    else if(event.keyCode === 39 && isVisible) { // right
       this.slideshow.slick('slickNext');
     }
   }

--- a/elements/bulbs-slick-slideshow/bulbs-slick-slideshow.test.js
+++ b/elements/bulbs-slick-slideshow/bulbs-slick-slideshow.test.js
@@ -1,64 +1,72 @@
 import { BulbsSlickSlideshow } from './bulbs-slick-slideshow';  // eslint-disable-line no-unused-vars
 
 describe('<bulbs-slick-slideshow>', () => {
+  let otherSubject;
+  let parentElement;
   let subject;
+
+  function attachSubject () {
+    parentElement = document.createElement('parent-element');
+    parentElement.appendChild(subject);
+    document.body.appendChild(parentElement);
+  }
 
   beforeEach(() => {
     subject = document.createElement('bulbs-slick-slideshow');
   });
 
   afterEach(() => {
-    subject.remove();
+    parentElement.remove();
   });
 
   it('renders a <bulbs-slick-slideshow>', () => {
-    subject.attachedCallback();
+    attachSubject();
 
     expect(subject.tagName.toLowerCase()).to.eql('bulbs-slick-slideshow');
   });
 
   describe('#init', () => {
     let slider;
-    let slideOne;
-    let slideTwo;
+    let slide;
     let sliderNav;
+    let otherSlider;
 
     beforeEach(() => {
       subject = document.createElement('bulbs-slick-slideshow');
-
       slider = document.createElement('div');
-      slider.setAttribute('class', 'slider');
-
-      slideOne = document.createElement('div');
-      slideOne.setAttribute('class', 'slide');
-      slideTwo = document.createElement('div');
-      slideTwo.setAttribute('class', 'slide');
-
+      slide = document.createElement('div');
       sliderNav = document.createElement('div');
+      slider.setAttribute('class', 'slider');
       sliderNav.setAttribute('class', 'slider-nav');
 
-      subject.appendChild(slideOne);
-      subject.appendChild(slideTwo);
+      slider.appendChild(slide);
       subject.appendChild(slider);
       subject.appendChild(sliderNav);
 
-      subject.attachedCallback();
+      otherSubject = document.createElement('bulbs-slick-slideshow');
+      otherSlider = slider.cloneNode(true);
+      otherSubject.appendChild(otherSlider);
 
-      sinon.spy(subject.slideshow, 'slick');
-
-
-      subject.init();
+      attachSubject();
     });
 
-    it('inits the jQuery slick carousel with the correct stuff', () => {
+    it('initializes the carousel with appropriate options', () => {
+      sinon.spy(subject.slideshow, 'slick');
+
+      subject.init();
+
       expect(subject.slideshow.slick).to.have.been.calledWith({
         infinite: false,
         arrows: false,
         dots: true,
         initialSlide: 0,
-        appendDots: subject.sliderNav,
+        appendDots: $('slider-nav'),
         customPaging: subject.customPaging,
       });
+    });
+
+    it('does not init other carousels on page', () => {
+      expect(otherSubject.slideshow).to.be.undefined;
     });
 
     it('has initial slide of 0', () => {
@@ -70,7 +78,7 @@ describe('<bulbs-slick-slideshow>', () => {
     let e = $.Event('keydown');
 
     beforeEach(() => {
-      subject.attachedCallback();
+      attachSubject();
 
       sinon.stub(subject.slideshow, 'slick');
     });

--- a/elements/bulbs-slick-slideshow/bulbs-slick-slideshow.test.js
+++ b/elements/bulbs-slick-slideshow/bulbs-slick-slideshow.test.js
@@ -33,8 +33,6 @@ describe('<bulbs-slick-slideshow>', () => {
     beforeEach(() => {
       subject = document.createElement('bulbs-slick-slideshow');
 
-      bufferElement = document.createElement('div');
-
       slider = document.createElement('div');
       slider.setAttribute('class', 'slider');
 
@@ -42,8 +40,7 @@ describe('<bulbs-slick-slideshow>', () => {
       navLinks.setAttribute('class', 'slider-nav');
 
       slider.appendChild(navLinks);
-      bufferElement.appendChild(slider);
-      subject.appendChild(bufferElement);
+      subject.appendChild(slider);
 
       attachSubject();
 

--- a/elements/bulbs-slick-slideshow/bulbs-slick-slideshow.test.js
+++ b/elements/bulbs-slick-slideshow/bulbs-slick-slideshow.test.js
@@ -38,7 +38,6 @@ describe('<bulbs-slick-slideshow>', () => {
       navLinks = document.createElement('div');
       navLinks.setAttribute('class', 'slider-nav');
       slider.appendChild(navLinks);
-
       subject.appendChild(slider);
 
       attachSubject();
@@ -65,7 +64,7 @@ describe('<bulbs-slick-slideshow>', () => {
   });
 
   describe('#bodyKeyDown', () => {
-    let e = $.Event('keydown'); // eslint-disable-line
+    let e = $.Event('keydown');
 
     beforeEach(() => {
       attachSubject();
@@ -73,25 +72,59 @@ describe('<bulbs-slick-slideshow>', () => {
       sinon.stub(subject.slideshow, 'slick');
     });
 
-    describe('press left arrow', () => {
+    describe('in viewport', () => {
       beforeEach(() => {
-        e.which = 37;
-        $(subject).trigger(e);
+        sinon.stub(subject, 'isInViewport').returns(false);
       });
 
-      it('tells slick to go to previous slide', () => {
-        expect(subject.slideshow.slick.calledWith('slickPrev'));
+      describe('press left arrow', () => {
+        beforeEach(() => {
+          e.which = 37;
+          $(subject).trigger(e);
+        });
+
+        it('tells slick to go to previous slide', () => {
+          expect(subject.slideshow.slick.calledWith('slickPrev'));
+        });
+      });
+
+      describe('press right arrow', () => {
+        beforeEach(() => {
+          e.which = 39;
+          $(subject).trigger(e);
+        });
+
+        it('tells slick to go to next slide', () => {
+          expect(subject.slideshow.slick.calledWith('slickNext'));
+        });
       });
     });
 
-    describe('press right arrow', () => {
+    describe('not in viewport', () => {
       beforeEach(() => {
-        e.which = 39;
-        $(subject).trigger(e);
+        sinon.stub(subject, 'isInViewport').returns(false);
       });
 
-      it('tells slick to go to next slide', () => {
-        expect(subject.slideshow.slick.calledWith('slickNext'));
+      describe('press left arrow', () => {
+        beforeEach(() => {
+          e.which = 37;
+          $(subject).trigger(e);
+        });
+
+        it('tells slick to go to previous slide', () => {
+          expect(subject.slideshow.slick).to.not.have.been.calledWith('slickPrev');
+        });
+      });
+
+      describe('press right arrow', () => {
+        beforeEach(() => {
+          e.which = 39;
+          $(subject).trigger(e);
+        });
+
+        it('tells slick to go to next slide', () => {
+          expect(subject.slideshow.slick).to.not.have.been.calledWith('slickNext');
+        });
       });
     });
   });

--- a/elements/bulbs-slick-slideshow/bulbs-slick-slideshow.test.js
+++ b/elements/bulbs-slick-slideshow/bulbs-slick-slideshow.test.js
@@ -32,13 +32,17 @@ describe('<bulbs-slick-slideshow>', () => {
     beforeEach(() => {
       subject = document.createElement('bulbs-slick-slideshow');
 
+      bufferElement = = document.createElement('div');
+
       slider = document.createElement('div');
       slider.setAttribute('class', 'slider');
 
       navLinks = document.createElement('div');
       navLinks.setAttribute('class', 'slider-nav');
+
       slider.appendChild(navLinks);
-      subject.appendChild(slider);
+      bufferElement.appendChild(slider);
+      subject.appendChild(bufferElement);
 
       attachSubject();
 

--- a/elements/bulbs-slick-slideshow/bulbs-slick-slideshow.test.js
+++ b/elements/bulbs-slick-slideshow/bulbs-slick-slideshow.test.js
@@ -26,13 +26,14 @@ describe('<bulbs-slick-slideshow>', () => {
   });
 
   describe('#init', () => {
+    let bufferElement;
     let navLinks;
     let slider;
 
     beforeEach(() => {
       subject = document.createElement('bulbs-slick-slideshow');
 
-      bufferElement = = document.createElement('div');
+      bufferElement = document.createElement('div');
 
       slider = document.createElement('div');
       slider.setAttribute('class', 'slider');
@@ -78,7 +79,7 @@ describe('<bulbs-slick-slideshow>', () => {
 
     describe('in viewport', () => {
       beforeEach(() => {
-        sinon.stub(subject, 'isInViewport').returns(false);
+        sinon.stub(subject, 'isInViewport').returns(true);
       });
 
       describe('press left arrow', () => {

--- a/elements/bulbs-slick-slideshow/bulbs-slick-slideshow.test.js
+++ b/elements/bulbs-slick-slideshow/bulbs-slick-slideshow.test.js
@@ -1,34 +1,27 @@
 import { BulbsSlickSlideshow } from './bulbs-slick-slideshow';  // eslint-disable-line no-unused-vars
 
 describe('<bulbs-slick-slideshow>', () => {
-  let parentElement;
   let subject;
-
-  function attachSubject () {
-    parentElement = document.createElement('parent-element');
-    parentElement.appendChild(subject);
-
-    subject.attachedCallback();
-  }
 
   beforeEach(() => {
     subject = document.createElement('bulbs-slick-slideshow');
   });
 
   afterEach(() => {
-    parentElement.remove();
+    subject.remove();
   });
 
   it('renders a <bulbs-slick-slideshow>', () => {
-    attachSubject();
+    subject.attachedCallback();
 
     expect(subject.tagName.toLowerCase()).to.eql('bulbs-slick-slideshow');
   });
 
   describe('#init', () => {
-    let bufferElement;
-    let navLinks;
     let slider;
+    let slideOne;
+    let slideTwo;
+    let sliderNav;
 
     beforeEach(() => {
       subject = document.createElement('bulbs-slick-slideshow');
@@ -36,15 +29,23 @@ describe('<bulbs-slick-slideshow>', () => {
       slider = document.createElement('div');
       slider.setAttribute('class', 'slider');
 
-      navLinks = document.createElement('div');
-      navLinks.setAttribute('class', 'slider-nav');
+      slideOne = document.createElement('div');
+      slideOne.setAttribute('class', 'slide');
+      slideTwo = document.createElement('div');
+      slideTwo.setAttribute('class', 'slide');
 
-      slider.appendChild(navLinks);
+      sliderNav = document.createElement('div');
+      sliderNav.setAttribute('class', 'slider-nav');
+
+      subject.appendChild(slideOne);
+      subject.appendChild(slideTwo);
       subject.appendChild(slider);
+      subject.appendChild(sliderNav);
 
-      attachSubject();
+      subject.attachedCallback();
 
       sinon.spy(subject.slideshow, 'slick');
+
 
       subject.init();
     });
@@ -55,7 +56,7 @@ describe('<bulbs-slick-slideshow>', () => {
         arrows: false,
         dots: true,
         initialSlide: 0,
-        appendDots: subject.navLinks,
+        appendDots: subject.sliderNav,
         customPaging: subject.customPaging,
       });
     });
@@ -69,7 +70,7 @@ describe('<bulbs-slick-slideshow>', () => {
     let e = $.Event('keydown');
 
     beforeEach(() => {
-      attachSubject();
+      subject.attachedCallback();
 
       sinon.stub(subject.slideshow, 'slick');
     });


### PR DESCRIPTION
two things here:
 - 1. more precise selector (fixes reading list initialization issue)
 - 2. isolate key events (current bug on prod - left/right controls slideshows outside of viewport, this prevents that)

#### info on bug:

`init` calls `_.initADA();` which calls this 👇 

`_.$slides.add(_.$slideTrack.find('.slick-cloned')).attr({`

where `_.$slides` is apparently `null`. (and that's where it's throwing error)

`$slides` is initialized in a few places, notably in `buildOut` (L506 in slick.js): 

```
_.$slides =
            _.$slider
                .children( _.options.slide + ':not(.slick-cloned)')
```

so tried adding children. but that didn't work 😞 