### PR TITLE
bulbs slideshow followup v2

### DIFF
--- a/elements/bulbs-slick-slideshow/bulbs-slick-slideshow.js
+++ b/elements/bulbs-slick-slideshow/bulbs-slick-slideshow.js
@@ -19,11 +19,7 @@ require('slick-carousel');
 /// 7. On l/r keydown, trigger slidechange.
 class BulbsSlickSlideshow extends BulbsHTMLElement {
   attachedCallback () {
-    this.slideshow = $('.slider');
-
-    if ($('.slider').length > 1) {
-      this.slideshow = $(this).find('.slider');
-    }
+    this.slideshow = $('.slider').last();
 
     // set variables
     this.initialSlide = 0;

--- a/elements/bulbs-slick-slideshow/bulbs-slick-slideshow.js
+++ b/elements/bulbs-slick-slideshow/bulbs-slick-slideshow.js
@@ -3,7 +3,8 @@ import {
   BulbsHTMLElement,
 } from 'bulbs-elements/register';
 import $ from 'jquery';
-import * as slick from 'slick-carousel'; // eslint-disable-line
+import * as slick from 'slick-carousel';
+import { InViewMonitor } from 'bulbs-elements/util';
 
 import './bulbs-slick-slideshow.scss';
 
@@ -18,6 +19,10 @@ import './bulbs-slick-slideshow.scss';
 class BulbsSlickSlideshow extends BulbsHTMLElement {
   attachedCallback () {
     this.slideshow = $('.slider');
+
+    if ($('.slider').length > 1) {
+      this.slideshow = $(this).find('.slider');
+    }
 
     // set variables
     this.initialSlide = 0;
@@ -87,11 +92,16 @@ class BulbsSlickSlideshow extends BulbsHTMLElement {
     this.slideshow.slick('slickGoTo', 0);
   }
 
+  isInViewport () {
+    return InViewMonitor.isElementInViewport(this.slideshow[0]);
+  }
+
   bodyKeyDown (event) {
-    if(event.keyCode === 37) { // left
+    const isVisible = this.isInViewport();
+    if(event.keyCode === 37 && isVisible) { // left
       this.slideshow.slick('slickPrev');
     }
-    else if(event.keyCode === 39) { // right
+    else if(event.keyCode === 39 && isVisible) { // right
       this.slideshow.slick('slickNext');
     }
   }

--- a/elements/bulbs-slick-slideshow/bulbs-slick-slideshow.js
+++ b/elements/bulbs-slick-slideshow/bulbs-slick-slideshow.js
@@ -3,10 +3,11 @@ import {
   BulbsHTMLElement,
 } from 'bulbs-elements/register';
 import $ from 'jquery';
-import * as slick from 'slick-carousel';
 import { InViewMonitor } from 'bulbs-elements/util';
 
 import './bulbs-slick-slideshow.scss';
+
+require('slick-carousel');
 
 /// Things this should do:
 /// 1. Initialize Slick slider for .slider elements.

--- a/elements/bulbs-slick-slideshow/bulbs-slick-slideshow.test.js
+++ b/elements/bulbs-slick-slideshow/bulbs-slick-slideshow.test.js
@@ -1,6 +1,7 @@
 import { BulbsSlickSlideshow } from './bulbs-slick-slideshow';  // eslint-disable-line no-unused-vars
 
 describe('<bulbs-slick-slideshow>', () => {
+  let otherSubject;
   let parentElement;
   let subject;
 
@@ -27,28 +28,32 @@ describe('<bulbs-slick-slideshow>', () => {
 
   describe('#init', () => {
     let navLinks;
+    let otherSlider;
     let slider;
 
     beforeEach(() => {
       subject = document.createElement('bulbs-slick-slideshow');
-
       slider = document.createElement('div');
       slider.setAttribute('class', 'slider');
-
       navLinks = document.createElement('div');
       navLinks.setAttribute('class', 'slider-nav');
-      slider.appendChild(navLinks);
 
+      slider.appendChild(navLinks);
       subject.appendChild(slider);
+
+      otherSubject = document.createElement('bulbs-slick-slideshow');
+      otherSlider = slider.cloneNode(true);
+      otherSubject.appendChild(otherSlider);
 
       attachSubject();
 
-      sinon.spy(subject.slideshow, 'slick');
-
-      subject.init();
     });
 
     it('inits the jQuery slick carousel with the correct stuff', () => {
+      sinon.spy(subject.slideshow, 'slick');
+
+      subject.init();
+
       expect(subject.slideshow.slick).to.have.been.calledWith({
         infinite: false,
         arrows: false,
@@ -59,13 +64,17 @@ describe('<bulbs-slick-slideshow>', () => {
       });
     });
 
+    it('does not init other carousels on page', () => {
+      expect(otherSubject.slideshow).to.be.undefined;
+    });
+
     it('has initial slide of 0', () => {
       expect(subject.initialSlide).to.equal(0);
     });
   });
 
   describe('#bodyKeyDown', () => {
-    let e = $.Event('keydown'); // eslint-disable-line
+    let e = $.Event('keydown');
 
     beforeEach(() => {
       attachSubject();
@@ -73,25 +82,59 @@ describe('<bulbs-slick-slideshow>', () => {
       sinon.stub(subject.slideshow, 'slick');
     });
 
-    describe('press left arrow', () => {
+    describe('in viewport', () => {
       beforeEach(() => {
-        e.which = 37;
-        $(subject).trigger(e);
+        sinon.stub(subject, 'isInViewport').returns(true);
       });
 
-      it('tells slick to go to previous slide', () => {
-        expect(subject.slideshow.slick.calledWith('slickPrev'));
+      describe('press left arrow', () => {
+        beforeEach(() => {
+          e.which = 37;
+          $(subject).trigger(e);
+        });
+
+        it('tells slick to go to previous slide', () => {
+          expect(subject.slideshow.slick.calledWith('slickPrev'));
+        });
+      });
+
+      describe('press right arrow', () => {
+        beforeEach(() => {
+          e.which = 39;
+          $(subject).trigger(e);
+        });
+
+        it('tells slick to go to next slide', () => {
+          expect(subject.slideshow.slick.calledWith('slickNext'));
+        });
       });
     });
 
-    describe('press right arrow', () => {
+    describe('not in viewport', () => {
       beforeEach(() => {
-        e.which = 39;
-        $(subject).trigger(e);
+        sinon.stub(subject, 'isInViewport').returns(false);
       });
 
-      it('tells slick to go to next slide', () => {
-        expect(subject.slideshow.slick.calledWith('slickNext'));
+      describe('press left arrow', () => {
+        beforeEach(() => {
+          e.which = 37;
+          $(subject).trigger(e);
+        });
+
+        it('tells slick to go to previous slide', () => {
+          expect(subject.slideshow.slick).to.not.have.been.calledWith('slickPrev');
+        });
+      });
+
+      describe('press right arrow', () => {
+        beforeEach(() => {
+          e.which = 39;
+          $(subject).trigger(e);
+        });
+
+        it('tells slick to go to next slide', () => {
+          expect(subject.slideshow.slick).to.not.have.been.calledWith('slickNext');
+        });
       });
     });
   });

--- a/elements/bulbs-slick-slideshow/bulbs-slick-slideshow.test.js
+++ b/elements/bulbs-slick-slideshow/bulbs-slick-slideshow.test.js
@@ -74,7 +74,7 @@ describe('<bulbs-slick-slideshow>', () => {
   });
 
   describe('#bodyKeyDown', () => {
-    let e = $.Event('keydown');
+    let e = $.Event('keydown');  // eslint-disable-line babel/new-cap
 
     beforeEach(() => {
       attachSubject();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bulbs-elements",
-  "version": "11.8.0",
+  "version": "11.8.1",
   "description": "Some registerable components for bulbs content types.",
   "main": "lib/bulbs-elements/bulbs-elements.js",
   "repository": "git@github.com:theonion/bulbs-elements.git",


### PR DESCRIPTION
cleaner commit than https://github.com/theonion/bulbs-elements/pull/241, didn't want to rebase

two things here:
 - 1. more precise selector (fixes reading list initialization issue for subsequent slideshows)
 - 2. isolate key events (current bug on prod - left/right controls slideshows outside of viewport, this prevents that)