### PR TITLE
allow a more specific clickable area in reading list menus

### DIFF
--- a/elements/bulbs-reading-list/components/bulbs-reading-list-menu-item-clickable-area.js
+++ b/elements/bulbs-reading-list/components/bulbs-reading-list-menu-item-clickable-area.js
@@ -1,0 +1,11 @@
+import {
+  registerElement,
+  BulbsHTMLElement,
+} from 'bulbs-elements/register';
+
+class BulbsReadingListMenuItemClickableArea extends BulbsHTMLElement {
+}
+
+registerElement('bulbs-reading-list-menu-item-clickable-area', BulbsReadingListMenuItemClickableArea);
+
+export default BulbsReadingListMenuItemClickableArea;

--- a/elements/bulbs-reading-list/lib/reading-list-menu-item.js
+++ b/elements/bulbs-reading-list/lib/reading-list-menu-item.js
@@ -19,7 +19,12 @@ export default class ReadingListMenuItem {
   }
 
   registerEvents () {
-    this.element.addEventListener('click', this.handleClick.bind(this));
+    let clickableArea = this.element.querySelector('bulbs-reading-list-menu-item-clickable-area');
+    if (!clickableArea) {
+      clickableArea = this.element;
+    }
+
+    clickableArea.addEventListener('click', this.handleClick.bind(this));
     this.dispatcher.on('reading-list-item-progress-update', this.updateProgress.bind(this));
   }
 

--- a/elements/bulbs-reading-list/lib/reading-list-menu-item.test.js
+++ b/elements/bulbs-reading-list/lib/reading-list-menu-item.test.js
@@ -80,11 +80,23 @@ describe('ReadingListMenuItem', () => {
   });
 
   describe('handleClick', () => {
+
     it('triggers an item click event', () => {
       let evnt = { preventDefault: sandbox.spy() };
       sandbox.stub(subject.dispatcher, 'emit');
       subject.handleClick(evnt);
       expect(subject.dispatcher.emit).to.have.been.calledWith('reading-list-item-clicked', subject, evnt);
+    });
+
+    it('should check for the presence of a bulbs-reading-list-menu-item-cickable-area to attach click event to', () => {
+      const clickableArea = $('<bulbs-reading-list-menu-item-clickable-area>');
+      element.appendChild(clickableArea[0]);
+      subject.registerEvents();
+      sandbox.stub(subject.dispatcher, 'emit');
+
+      clickableArea.trigger('click');
+
+      expect(subject.dispatcher.emit).to.have.been.calledWith('reading-list-item-clicked', subject);
     });
   });
 });


### PR DESCRIPTION
Allows a more limited clickable area in a reading list menu item, addresses the issue where we want the feature type and campaign to be clickable for their own URLs apart from scrolling to a reading list article.