### PR TITLE
call iFrameResize with each iframe

### DIFF
--- a/elements/bulbs-article-body/bulbs-article-body.js
+++ b/elements/bulbs-article-body/bulbs-article-body.js
@@ -46,10 +46,9 @@ class BulbsArticleBody extends BulbsHTMLElement {
 
   resizeIframes () {
     if (window.iFrameResize) {
-      window.iFrameResize(
-        { checkOrigin: false },
-        this.querySelectorAll('iframe.onionstudios-playlist')
-      );
+      [].forEach.call(this.querySelectorAll('iframe.onionstudios-playlist'), (iframe) => {
+        window.iFrameResize({ checkOrigin: false }, iframe);
+      });
     }
   }
 

--- a/elements/bulbs-article-body/bulbs-article-body.test.js
+++ b/elements/bulbs-article-body/bulbs-article-body.test.js
@@ -140,7 +140,7 @@ describe('<bulbs-article-body>', () => {
       document.body.appendChild(subject);
       setImmediate(() => {
         expect(window.iFrameResize.args[0][0]).to.eql({ checkOrigin: false });
-        expect(window.iFrameResize.args[0][1][0]).to.eql(subject.querySelector('.onionstudios-playlist'));
+        expect(window.iFrameResize.args[0][1]).to.eql(subject.querySelector('.onionstudios-playlist'));
         done();
       });
     });


### PR DESCRIPTION
This was passing the result of `querySelectorAll` into `iFrameResize` which caused a type error. Now it calls iFrameResize with each iframe individually.

I believe I had tested against a different version of iFrameResize / got confused by test branch deployment failures.