### PR TITLE
GA_ID to GOOGLE_ANALYTICS_ID

### DIFF
--- a/elements/bulbs-reading-list/lib/reading-list-article.js
+++ b/elements/bulbs-reading-list/lib/reading-list-article.js
@@ -14,7 +14,7 @@ export default class ReadingListArticle {
     invariant(element, 'new ReadingListArticle(element, dispatcher, index): element is undefined');
     invariant(dispatcher, 'new ReadingListArticle(element, dispatcher, index): dispatcher is undefined');
     invariant(!isUndefined(index), 'new ReadingListArticle(element, dispatcher, index): index is undefined');
-    invariant(!isUndefined(window.GA_ID), 'new ReadingListArticle, GA_ID must be set on window');
+    invariant(!isUndefined(window.GOOGLE_ANALYTICS_ID), 'new ReadingListArticle, GOOGLE_ANALYTICS_ID must be set on window');
     element.requireAttribute('data-content-analytics-dimensions');
 
     this.element = element;
@@ -61,7 +61,7 @@ export default class ReadingListArticle {
   prepGaTracker () {
     return prepGaEventTracker(
       'pageview',
-      window.GA_ID,
+      window.GOOGLE_ANALYTICS_ID,
       this.dimensions,
     );
   }

--- a/elements/bulbs-reading-list/lib/reading-list-article.test.js
+++ b/elements/bulbs-reading-list/lib/reading-list-article.test.js
@@ -17,7 +17,7 @@ describe('ReadingListArticle', () => {
   let contentAnalyticsDimensions;
 
   beforeEach(() => {
-    window.GA_ID = '7';
+    window.GOOGLE_ANALYTICS_ID = '7';
     id = 1;
     index = 0;
     href = 'http://example.com';

--- a/elements/bulbs-reading-list/lib/reading-list-articles.test.js
+++ b/elements/bulbs-reading-list/lib/reading-list-articles.test.js
@@ -20,7 +20,7 @@ describe('ReadingListArticles', () => {
   let contentAnalyticsDimensions;
 
   beforeEach(() => {
-    window.GA_ID = 'funky';
+    window.GOOGLE_ANALYTICS_ID = 'funky';
     readingListId = 1;
     id = 0;
     href = 'http://example.com';


### PR DESCRIPTION
Will be released together with the changes in https://github.com/theonion/omni/pull/870. Renames `GA_` variable prefixes to `GOOGLE_ANALYTICS_` for clarity.

### Release Type: _major_
Will break existing functionality if sites references to these variables are not renamed.