### PR TITLE
Updating preroll ad unit size

### DIFF
--- a/elements/bulbs-video/components/revealed.js
+++ b/elements/bulbs-video/components/revealed.js
@@ -169,7 +169,7 @@ export default class Revealed extends React.Component {
     let vastTestId = this.vastTest(window.location.search);
 
     // See docs (https://support.google.com/dfp_premium/answer/1068325?hl=en) for param info
-    baseUrl += '?sz=400x300';
+    baseUrl += '?sz=640x480';
     baseUrl += `&iu=/4246/${window.Bulbs.settings.DFP_SITE_CODE}`;
     baseUrl += '&impl=s';
     baseUrl += '&gdfp_req=1';

--- a/elements/bulbs-video/components/revealed.test.js
+++ b/elements/bulbs-video/components/revealed.test.js
@@ -596,7 +596,7 @@ describe('<bulbs-video> <Revealed>', () => {
         expect(parsed.host).to.eql('pubads.g.doubleclick.net');
         expect(parsed.pathname).to.eql('/gampad/ads');
         expect(Object.keys(parsed.query)).to.eql(['sz', 'iu', 'impl', 'gdfp_req', 'env', 'output', 'unviewed_position_start', 'url', 'description_url', 'correlator', 'cust_params']);
-        expect(parsed.query.sz).to.eql('400x300');
+        expect(parsed.query.sz).to.eql('640x480');
         expect(parsed.query.iu).to.eql('/4246/fmg.onion');
         expect(parsed.query.impl).to.eql('s');
         expect(parsed.query.gdfp_req).to.eql('1');


### PR DESCRIPTION
This PR simply adjusts the ad unit size that maps to standard preroll in the ad server.  It was previously 400x300 and should have been 640x480 all along.

Test links are reflected in the omni PR: https://github.com/theonion/omni/pull/943

This would be a `patch` release.