### PR TITLE
Add a new value for type to be used for possible preroll exclusion

### DIFF
--- a/elements/bulbs-video/components/revealed.js
+++ b/elements/bulbs-video/components/revealed.js
@@ -167,6 +167,7 @@ export default class Revealed extends React.Component {
     let baseUrl = 'https://pubads.g.doubleclick.net/gampad/ads';
 
     let vastTestId = this.vastTest(window.location.search);
+    let type;
 
     // See docs (https://support.google.com/dfp_premium/answer/1068325?hl=en) for param info
     baseUrl += '?sz=640x480';
@@ -188,6 +189,7 @@ export default class Revealed extends React.Component {
 
     if (this.props.targetCampaignId) {
       customParamValues += `&dfp_campaign_id=${this.props.targetCampaignId}`;
+      type = 'sponsored';
     }
 
     if (videoMeta.series_slug) {
@@ -196,7 +198,11 @@ export default class Revealed extends React.Component {
 
     if (videoMeta.specialCoverage) {
       customParamValues += `&dfp_specialcoverage=${videoMeta.specialCoverage}`;
-      customParamValues += `&type=special_coverage`;
+      type = 'special_coverage';
+    }
+
+    if (type) {
+      customParamValues += `&type=${type}`;
     }
 
     if (vastTestId) {

--- a/elements/bulbs-video/components/revealed.test.js
+++ b/elements/bulbs-video/components/revealed.test.js
@@ -641,6 +641,7 @@ describe('<bulbs-video> <Revealed>', () => {
           let parsed = url.parse(vastUrl, true);
           let cust_params = querystring.parse(parsed.query.cust_params, '&');
           expect(cust_params.dfp_campaign_id).to.equal('1');
+          expect(cust_params.type).to.equal('sponsored');
         });
       });
 


### PR DESCRIPTION
This simply adds a new possible value for the`type` custom param key/value, to pass in a blanket `sponsored` type in instances where a stand-alone video might be sponsored (defined herein as the presence of the `targetCampaignId`).  It will make it easier to globally exclude any sponsored video from affected line items on the ops side.

Will be a `minor` release.