### PR TITLE
update analytics using `InViewMonitor` events 

### DIFF
--- a/elements/bulbs-reading-list/lib/reading-list-article.js
+++ b/elements/bulbs-reading-list/lib/reading-list-article.js
@@ -132,7 +132,6 @@ export default class ReadingListArticle {
 
   handleScroll (offset) {
     const newProgress = this.calculateProgress(offset);
-    // this.pushStateIfStartedReading(this.progress, newProgress);
     this.progress = newProgress;
     this.dispatcher.emit('reading-list-item-progress-update', this);
   }


### PR DESCRIPTION
# Update
this will eventually be fully refactored but in order to prevent numerous analytics events from firing, made use of `InViewMonitor` similar to the implementation in `bulbs-page` and the utilility @collin made here https://github.com/theonion/bulbs-elements/pull/267
This change should fix the behavior on all 3 properties

# Test 
[Avclub](http://avc-refresh-article-scroll.test.avclub.com/article/career-suicide-thrashes-back-life-tighten-screws-249512)
[onion](http://update-analytics.test.theonion.com)
[clickhole](http://update-analytics.test.clickhole.com)