### PR TITLE
pulling out analyicsManager change

### DIFF
--- a/elements/bulbs-page/bulbs-page.test.js
+++ b/elements/bulbs-page/bulbs-page.test.js
@@ -14,7 +14,7 @@ describe('<bulbs-page>', () => {
   beforeEach(() => {
     mockRaf = createMockRaf();
     sandbox = sinon.sandbox.create();
-    window.onionan = {
+    window.analyticsManager = {
       trackPageView () {},
     };
     sandbox.stub(window, 'requestAnimationFrame', mockRaf.raf);
@@ -32,7 +32,7 @@ describe('<bulbs-page>', () => {
 
   afterEach(() => {
     sandbox.restore();
-    delete window.onionan;
+    delete window.analyticsManager;
   });
 
   describe('attachedCallback', () => {

--- a/elements/bulbs-slick-slideshow/bulbs-slick-slideshow.js
+++ b/elements/bulbs-slick-slideshow/bulbs-slick-slideshow.js
@@ -109,7 +109,7 @@ class BulbsSlickSlideshow extends BulbsHTMLElement {
 
   slideshowChanged (event, slickObject, currentSlide) {
     window.location.hash = currentSlide;
-    window.onionan.trackPageView(true);
+    window.analyticsManager.trackPageView(true);
     this.enableDisableNav(this.slides, currentSlide);
   }
 

--- a/lib/bulbs-elements/util/get-analytics-manager.js
+++ b/lib/bulbs-elements/util/get-analytics-manager.js
@@ -1,30 +1,4 @@
-/*
-FIXME: videohub-player depends on there being an instance of our analytics manager
-        at window.AnalyticsManager.
-        Some possible solutions:
-        1. Have bulbs-video and/or videohub-player initialize their own
-           analytics manager
-        2. Have bulbs-video and/or videohub-player use a confuration
-           such as BULBS_ELEMENTS_ANALYTICS_MANAGER.
-        3. Have all sites follow a convention for where AnalyticsManager
-           lives.
-*/
-/* global avclubAnalytics, onionan, clickholean, starwipe */
-
 export default function () {
-  let analyticsManager;
-  if (window.avclubAnalytics) {
-    analyticsManager = avclubAnalytics;
-  }
-  else if (window.onionan) {
-    analyticsManager = onionan;
-  }
-  else if (window.clickholean) {
-    analyticsManager = clickholean;
-  }
-  else if (window.starwipe) {
-    analyticsManager = starwipe.analyticsManager;
-  }
-  return analyticsManager;
+  // Global default
+  return window.analyticsManager;
 }
-


### PR DESCRIPTION
going to roll this out separately to start getting thing out - this just updates the global var to be `analyticsManager` 

was a part of https://github.com/theonion/bulbs-elements/pull/271 but will continue work on that for passing analytics manager through to track events correctly