### PR TITLE
Added new inview-rect event so event listeners can use that info how they choose

### DIFF
--- a/lib/bulbs-elements/util/in-view-monitor.js
+++ b/lib/bulbs-elements/util/in-view-monitor.js
@@ -85,7 +85,6 @@ const maybeEmitEvent = (monitoredItem) => {
     monitoredItem.element.dispatchEvent(event);
   }
 
-
   if (scrollPercent !== previousScroll) {
     monitoredItem.scrollPercent = scrollPercent;
     let event = new CustomEvent('progresschange', {

--- a/lib/bulbs-elements/util/in-view-monitor.js
+++ b/lib/bulbs-elements/util/in-view-monitor.js
@@ -76,6 +76,16 @@ const maybeEmitEvent = (monitoredItem) => {
     monitoredItem.element.dispatchEvent(event);
   }
 
+  if (inView) {
+    let event = new CustomEvent('inviewrect', {
+      detail: {
+        boundingRect: monitoredItem.latestRect || monitoredItem.element.getBoundingClientRect(),
+      },
+    });
+    monitoredItem.element.dispatchEvent(event);
+  }
+
+
   if (scrollPercent !== previousScroll) {
     monitoredItem.scrollPercent = scrollPercent;
     let event = new CustomEvent('progresschange', {

--- a/lib/bulbs-elements/util/in-view-monitor.test.js
+++ b/lib/bulbs-elements/util/in-view-monitor.test.js
@@ -191,6 +191,22 @@ describe('InViewMonitor', () => {
     });
   });
 
+  describe('inview rect events', () => {
+    let spy;
+    beforeEach(() => spy = sinon.spy());
+
+    it('emits inview rect event with bounding rect of element', () => {
+      el.style.top = window.innerHeight + 200 + 'px';
+      InViewMonitor.add(el);
+      el.addEventListener('inviewrect', (event) => {
+        expect(event.detail.boundingRect.top).to.equal(100);
+        done();
+      });
+      el.style.top = '100px';
+      InViewMonitor.checkElement(el);
+    });
+  });
+
   describe('progress events', () => {
     let spy;
     beforeEach(() => spy = sinon.spy());

--- a/lib/bulbs-elements/util/in-view-monitor.test.js
+++ b/lib/bulbs-elements/util/in-view-monitor.test.js
@@ -192,10 +192,7 @@ describe('InViewMonitor', () => {
   });
 
   describe('inview rect events', () => {
-    let spy;
-    beforeEach(() => spy = sinon.spy());
-
-    it('emits inview rect event with bounding rect of element', () => {
+    it('emits inview rect event with bounding rect of element', (done) => {
       el.style.top = window.innerHeight + 200 + 'px';
       InViewMonitor.add(el);
       el.addEventListener('inviewrect', (event) => {


### PR DESCRIPTION
This PR will be used in a subsequent change to allow `reading-list-article` to listen to its own `inview-rect` events and trigger the page start logic to match the old way using the pixel positioning of itself.