### PR TITLE
bulbs-page default for content analytics dimensions

### DIFF
--- a/elements/bulbs-page/bulbs-page.js
+++ b/elements/bulbs-page/bulbs-page.js
@@ -19,6 +19,13 @@ let pageStartDebouncer = debouncePerFrame();
 
 export default class BulbsPage extends BulbsHTMLElement {
   attachedCallback () {
+    const markdownText = '<bulbs-page> requires attribute: ';
+
+    invariant(
+      this.dataset.contentAnalyticsDimensions,
+      markdownText + 'data-content-analytics-dimensions'
+    );
+
     this.requireAttribute('pushstate-url');
     InViewMonitor.add(this);
     onReadyOrNow(() => this.handleDocumentReady());
@@ -31,7 +38,7 @@ export default class BulbsPage extends BulbsHTMLElement {
 
   get dimensions () {
     let targeting = JSON.parse(
-      this.dataset.contentAnalyticsDimensions || {}
+      this.dataset.contentAnalyticsDimensions || '{}'
     );
 
     return {

--- a/elements/bulbs-page/bulbs-page.js
+++ b/elements/bulbs-page/bulbs-page.js
@@ -31,8 +31,9 @@ export default class BulbsPage extends BulbsHTMLElement {
 
   get dimensions () {
     let targeting = JSON.parse(
-      this.dataset.contentAnalyticsDimensions
+      this.dataset.contentAnalyticsDimensions || {}
     );
+
     return {
       'dimension1': targeting.dimension1 || 'None',
       'dimension2': targeting.dimension2 || 'None',

--- a/elements/bulbs-page/bulbs-page.js
+++ b/elements/bulbs-page/bulbs-page.js
@@ -10,6 +10,8 @@ import {
   registerElement,
   BulbsHTMLElement,
 } from 'bulbs-elements/register';
+import invariant from 'invariant';
+
 import './bulbs-page.scss';
 
 // if we scroll past multiple pages at once they will all trigger a

--- a/elements/bulbs-video/components/revealed.test.js
+++ b/elements/bulbs-video/components/revealed.test.js
@@ -340,7 +340,7 @@ describe('<bulbs-video> <Revealed>', () => {
       revealed = new Revealed({});
       revealed.player = {
         setMute: sandbox.spy(),
-        remove: sandbox.spy()
+        remove: sandbox.spy(),
       };
       remove = sandbox.stub(util.InViewMonitor, 'remove');
       revealed.componentWillUnmount();


### PR DESCRIPTION
Fix for json parsing error when content analytics aren't defined on `bulbs-page` element.

### Release Type: _patch_
Only a fix.