### PR TITLE
prevent tracking stuff if url has not changed

### DIFF
--- a/elements/bulbs-page/bulbs-page.js
+++ b/elements/bulbs-page/bulbs-page.js
@@ -131,6 +131,10 @@ export default class BulbsPage extends BulbsHTMLElement {
       this.gaTrackerWrapper = this.prepGaTracker();
     }
 
+    if (this.isCurrentPage()) {
+      return;
+    }
+
     history.replaceState(
       {},
       this.getAttribute('pushstate-title'),

--- a/elements/bulbs-page/bulbs-page.test.js
+++ b/elements/bulbs-page/bulbs-page.test.js
@@ -179,6 +179,17 @@ describe('<bulbs-page>', () => {
         ).once;
       });
     });
+
+    it('should not do in view tasks if the url is already pointing to the current page', () => {
+      mockRaf.cancel();
+      sinon.stub(element, 'isCurrentPage').returns(true);
+
+      element.handleInViewAndInFocus();
+      mockRaf.step();
+
+      expect(history.replaceState).to.not.have.been.called;
+      expect(util.getAnalyticsManager().trackPageView).to.not.have.been.called;
+    });
   });
 
   describe('handleInView', () => {


### PR DESCRIPTION
Prevent `scroll_view` events unless the url has changed.

### Release Type: _patch_
