### PR TITLE
highlight first carousel item on first video play

### DIFF
--- a/elements/bulbs-video/elements/video-carousel.js
+++ b/elements/bulbs-video/elements/video-carousel.js
@@ -57,10 +57,7 @@ class BulbsVideoCarousel extends BulbsHTMLElement {
       '<bulbs-video-carousel> MUST contain a <bulbs-carousel>'
     );
 
-    // Removing for now, causing issue with videos autoplaying in background
-    //  - bryce, 2/22/17
-    // this.videoPlayer.addEventListener('jw-beforePlay', this.firstPlay = this.firstPlay.bind(this), true);
-
+    this.videoPlayer.addEventListener('jw-beforePlay', this.firstPlay = this.firstPlay.bind(this), true);
     this.videoPlayer.addEventListener('jw-complete', this.playerEnded = this.playerEnded.bind(this), true);
     this.carousel.addEventListener('click', this.handleClick = this.handleClick.bind(this));
 
@@ -70,15 +67,14 @@ class BulbsVideoCarousel extends BulbsHTMLElement {
   }
 
   firstPlay () {
-    let items = this.querySelectorAll('bulbs-carousel-item');
-    let nowPlayingItems = this.querySelectorAll('[now-playing]');
+    this.videoPlayer.removeEventListener('jw-beforePlay', this.firstPlay, true);
 
-    if (nowPlayingItems.length > 0 && items.length > 0) {
+    let items = this.querySelectorAll('bulbs-carousel-item');
+
+    if (items.length > 0) {
       this.selectItem(items[0]);
       this.applyState();
     }
-
-    this.videoPlayer.removeEventListener('jw-beforePlay', this.firstPlay, true);
   }
 
   playerEnded () {
@@ -93,6 +89,8 @@ class BulbsVideoCarousel extends BulbsHTMLElement {
   }
 
   handleClick (event) {
+    this.videoPlayer.removeEventListener('jw-beforePlay', this.firstPlay, true);
+
     let item = event.target.closest('bulbs-carousel-item');
     if (item) {
       let anchor = item.querySelector('a');

--- a/elements/bulbs-video/elements/video-carousel.test.js
+++ b/elements/bulbs-video/elements/video-carousel.test.js
@@ -74,7 +74,7 @@ describe('<bulbs-video-carousel>', () => {
 
   describe('attachedCallback', () => {
     // Skipping for now - see notes in method
-    xit('attaches firstPlay handler to videoPlayer', () => {
+    it('attaches firstPlay handler to videoPlayer', () => {
       subject.attachedCallback();
       expect(videoPlayer.addEventListener).to.have.been.calledWith(
         'jw-beforePlay',


### PR DESCRIPTION
Undoes changes in #259 to allow first item to be highlighted on first play. Note, the underlying issue in #259 where two videos would play at the same time should be fixed by the hack in #285.

### Release Type: _patch_
No breaking changes, only fixes.

### Updates
1. Adds back functionality that selects first carousel item when playing the first video for the first time.
2. Fixes an issue where selecting an item other than the first as the first play switches the carousel back to the first item and plays that.