### PR TITLE
fix internals of stateless components, bulbs-video autoplay

### DIFF
--- a/elements/bulbs-video/bulbs-video.js
+++ b/elements/bulbs-video/bulbs-video.js
@@ -26,7 +26,9 @@ export default class BulbsVideo extends BulbsElement {
   }
 
   componentDidUpdate (prevProps) {
-    if (this.props.src !== prevProps.src) {
+    if (this.props.src !== prevProps.src ||
+        this.props.autoplay !== prevProps.autoplay) {
+
       this.store.actions.resetController();
       this.store.actions.setVideoField(null); // eslint-disable-line no-undefined
       requestAnimationFrame(() => {

--- a/elements/bulbs-video/bulbs-video.test.js
+++ b/elements/bulbs-video/bulbs-video.test.js
@@ -7,9 +7,11 @@ import fetchMock from 'fetch-mock';
 import { scrollingElement } from 'bulbs-elements/util';
 
 describe('<bulbs-video>', () => {
+  let autoplay = '';
   let src = '//example.org/video-src.json';
   let subject;
   let props = {
+    autoplay,
     src,
     disableLazyLoading: true,
   };
@@ -54,16 +56,17 @@ describe('<bulbs-video>', () => {
     let fetchSpy;
     let resetSpy;
     let newSrc;
+    let newAutoplay;
 
     beforeEach(() => {
       subject = new BulbsVideo(props);
     });
 
-    context('src did not change', () => {
+    context('src and autoplay did not change', () => {
       beforeEach(() => {
         fetchSpy = sinon.spy(subject.store.actions, 'fetchVideo');
         resetSpy = sinon.spy(subject.store.actions, 'resetController');
-        subject.componentDidUpdate({ src });
+        subject.componentDidUpdate({ autoplay, src });
         newSrc = src;
       });
 
@@ -84,6 +87,31 @@ describe('<bulbs-video>', () => {
         fetchMock.mock(newSrc, {});
         subject.props.src = newSrc;
         subject.componentDidUpdate({ src });
+      });
+
+      it('fetches video data', (done) => {
+        setImmediate(() => {
+          expect(fetchSpy).to.have.been.calledWith(newSrc);
+          done();
+        });
+      });
+
+      it('resets the controller', (done) => {
+        setImmediate(() => {
+          expect(resetSpy).to.have.been.called;
+          done();
+        });
+      });
+    });
+
+    context('autoplay did change', () => {
+      beforeEach(() => {
+        fetchSpy = sinon.spy(subject.store.actions, 'fetchVideo');
+        resetSpy = sinon.spy(subject.store.actions, 'resetController');
+        newAutoplay = false;
+        fetchMock.mock(src, {});
+        subject.props.autoplay = newAutoplay;
+        subject.componentDidUpdate({ autoplay, src });
       });
 
       it('fetches video data', (done) => {

--- a/lib/bulbs-elements/register.js
+++ b/lib/bulbs-elements/register.js
@@ -61,7 +61,7 @@ export function registerReactElement (tagName, ReactComponent) {
       skip the rendering step.
     */
     attachedCallback () {
-      if (!this.reactInstance) {
+      if (!this.rendered) {
         this.doRender();
       }
     }
@@ -76,7 +76,7 @@ export function registerReactElement (tagName, ReactComponent) {
     }
 
     attributeChangedCallback () {
-      if (this.reactInstance) {
+      if (this.rendered) {
         this.doRender();
       }
     }
@@ -86,6 +86,13 @@ export function registerReactElement (tagName, ReactComponent) {
         ReactComponent,
         this.attributesHash
       );
+      this.rendered = true;
+
+      // NOTE: this will only fill in for elements that are stateful, stateless
+      //  components will have this property as `null`. From ReactDOM.render
+      //  docs, "Render a React element into the DOM in the supplied
+      //  `container` and return a reference to the component (or returns
+      //  `null` for stateless components."
       this.reactInstance = ReactDOM.render(
         renderableReactElement,
         this.mountPoint


### PR DESCRIPTION
Fixes register functionality for stateless components. Allows the carousel to play the first video when  clicking on the first carousel item before clicking on any other carousel item.

### Release Type: _patch_
Small patches for existing issues.

### Updates
1. `registerReactElement` now keeps a flag separate of the `reactInstance` variable to determine if a component has rendered at least once. This allows the `attributeChanged` callback to treat stateful and stateless components the same way.
2. `bulbs-video` is now sensitive to updates to the `autoplay` attribute.