### PR TITLE
add analytics to nav

### DIFF
--- a/elements/bulbs-nav/bulbs-nav.js
+++ b/elements/bulbs-nav/bulbs-nav.js
@@ -1,4 +1,5 @@
 import { registerElement, BulbsHTMLElement } from 'bulbs-elements/register';
+import util from 'bulbs-elements/util';
 import './bulbs-nav.scss';
 
 class BulbsNavToggle extends BulbsHTMLElement {
@@ -13,6 +14,11 @@ class BulbsNavToggle extends BulbsHTMLElement {
 
   toggleNavPanel (event) {
     event.stopPropagation();
+    util.getAnalyticsManager().sendEvent({
+      eventCategory: 'Nav',
+      eventAction: event.target.dataset.trackAction,
+      eventLabel: event.target.dataset.trackLabel,
+    });
     [].forEach.call(this.navPanels, navPanel => navPanel.toggle());
   }
 }

--- a/elements/bulbs-nav/bulbs-nav.test.js
+++ b/elements/bulbs-nav/bulbs-nav.test.js
@@ -1,3 +1,4 @@
+import util from 'bulbs-elements/util';
 import './bulbs-nav';
 
 describe('bulbs-nav', () => {
@@ -24,12 +25,15 @@ describe('bulbs-nav', () => {
 
     toggleA = container.querySelector('bulbs-nav-toggle[nav-name="panel-a"]');
     toggleB = container.querySelector('bulbs-nav-toggle[nav-name="panel-b"]');
+    sandbox.stub(util, 'getAnalyticsManager', () => {
+      return { sendEvent: sandbox.stub() };
+    });
 
     setTimeout(() => done());
   });
 
   afterEach(() => {
-    sandbox.reset();
+    sandbox.restore();
     container.remove();
   });
 


### PR DESCRIPTION
# What's all this about?
`bulbs-nav` is stopping event propagation which was messing with click tracking events on avclub. This pr adds click tracking.

# Test
link: http://avc-mobile-nav.test.avclub.com
open the javascript console and type this command `window.analyticsTest = true` then click on the nav and you should see events firing for the nav