### PR TITLE
`bulbs-nav` ScrollTop

### DIFF
--- a/elements/bulbs-nav/bulbs-nav.js
+++ b/elements/bulbs-nav/bulbs-nav.js
@@ -68,12 +68,22 @@ class BulbsNavPanel extends BulbsHTMLElement {
     document.body.removeEventListener('click', this.documentClickHandler);
   }
 
+  pinTabToTop (el) {
+    requestAnimationFrame(() => {
+      let navMenu = el.closest('#header-drawer');
+      if (navMenu) {
+        navMenu.scrollTop += el.getBoundingClientRect().top;
+      }
+    });
+  }
+
   toggle () {
     if (this.classList.contains('bulbs-nav-panel-active')) {
       this.close();
     }
     else {
       this.open();
+      this.pinTabToTop(this.parentElement);
     }
   }
 

--- a/elements/bulbs-nav/bulbs-nav.js
+++ b/elements/bulbs-nav/bulbs-nav.js
@@ -70,7 +70,7 @@ class BulbsNavPanel extends BulbsHTMLElement {
 
   pinTabToTop (el) {
     requestAnimationFrame(() => {
-      let navMenu = el.closest('#header-drawer');
+      let navMenu = el.closest('.modern.bulbs-flyover-open');
       if (navMenu) {
         navMenu.scrollTop += el.getBoundingClientRect().top;
       }

--- a/package.json
+++ b/package.json
@@ -139,6 +139,9 @@
   },
   "devDependencies": {
     "chai-spies": "^0.7.1",
-    "mock-raf": "^0.1.0"
+    "enzyme": "^2.8.1",
+    "mock-raf": "^0.1.0",
+    "react-addons-test-utils": "^15.5.1",
+    "react-dom": "^15.5.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
     "enzyme": "^2.8.1",
     "mock-raf": "^0.1.0",
     "react-addons-test-utils": "^15.5.1",
-    "react-dom": "^15.5.4"
+    "react-dom": "^15.5.4",
+    "react-test-renderer": "^15.5.4"
   }
 }


### PR DESCRIPTION
# What's this all about?
This adds a feature to the avclub mobile nav. When a menu item is toggled `open` that element is then pushed to the top of the screen.

# Test
open  http://nav-scroll-test.test.avclub.com in a mobile environment. Any element that is toggled open should snap to the top of the screen.