### PR TITLE
loadOnDemand improvements

### DIFF
--- a/elements/campaign-display/campaign-display.js
+++ b/elements/campaign-display/campaign-display.js
@@ -3,6 +3,7 @@ import invariant from 'invariant';
 
 import BulbsElement from 'bulbs-elements/bulbs-element';
 import { registerReactElement } from 'bulbs-elements/register';
+import { loadOnDemand } from 'bulbs-elements/util';
 
 import './campaign-display.scss';
 
@@ -62,7 +63,7 @@ Object.assign(CampaignDisplay, {
   },
 });
 
-registerReactElement('campaign-display', CampaignDisplay);
+registerReactElement('campaign-display', loadOnDemand(CampaignDisplay));
 
 export default CampaignDisplay;
 export const displayPropType = CampaignDisplay.propTypes.display;

--- a/lib/bulbs-elements/util/load-on-demand.js
+++ b/lib/bulbs-elements/util/load-on-demand.js
@@ -21,6 +21,7 @@ import React, { PropTypes } from 'react';
 
 addEventListener('resize', maybeLoadComponents);
 addEventListener('scroll', maybeLoadComponents, true);
+addEventListener('bulbs-load', maybeLoadComponents);
 
 const pendingComponents = [];
 let animationFrameRequested = false;
@@ -79,7 +80,10 @@ function shouldComponentLoad (component) {
   // );
 
   let rect = component.refs.sentinel.getBoundingClientRect();
-  return rect.bottom > -distanceFromTop && rect.top < window.innerHeight + distanceFromBottom;
+  let inViewingPane = rect.bottom > -distanceFromTop && rect.top < window.innerHeight + distanceFromBottom;
+  let isVisible = !!(component.refs.sentinel.offsetWidth || component.refs.sentinel.offsetHeight || component.refs.sentinel.getClientRects().length);
+
+  return isVisible && inViewingPane;
 }
 
 function loadComponent (component) {

--- a/lib/bulbs-elements/util/load-on-demand.test.js
+++ b/lib/bulbs-elements/util/load-on-demand.test.js
@@ -41,6 +41,35 @@ describe('loadOnDemand', () => {
 
   });
 
+  context('element is within viewing zone, but display hidden', () => {
+    beforeEach((done) => {
+      container = document.createElement('div');
+      container.innerHTML = `
+        <div-on-demand
+          style="
+            position: absolute;
+            top: 0px;
+            left: 0px;
+            display: none;
+            width: 10px;
+            height: 10px;
+          "
+        >
+        </div-on-demand>
+      `;
+      document.body.appendChild(container);
+      setImmediate(() => done());
+    });
+
+    afterEach(() => {
+      container.remove();
+    });
+
+    it('does not load', () => {
+      expect(onDemand.length).to.equal(0);
+    });
+  });
+
   context('element moves into viewing zone', () => {
     beforeEach((done) => {
       container = document.createElement('div');
@@ -89,6 +118,22 @@ describe('loadOnDemand', () => {
       catch (error) {
         const event = document.createEvent('Event');
         event.initEvent('resize', false, true);
+        window.dispatchEvent(event);
+      }
+      requestAnimationFrame(() => {
+        expect(onDemand.length).to.eql(1);
+        done();
+      });
+    });
+
+    it('loads if externally triggered', (done) => {
+      container.firstElementChild.style.top = '0px';
+      try {
+        window.dispatchEvent(new Event('bulbs-load'));
+      }
+      catch (error) {
+        const event = document.createEvent('Event');
+        event.initEvent('bulbs-load', false, true);
         window.dispatchEvent(event);
       }
       requestAnimationFrame(() => {


### PR DESCRIPTION
This PR does the following:

- Made campaign-display use `loadOnDemand`, e.g. lazy loaded
- Makes sure `loadOnDemand` does not load hidden elements even if they are "in the view port"
- Provides an external event (`bulbs-load`) to trigger evaluation of loading elements in addition to `scroll` and `resize`

Note, that the `isVisible` check in this PR is shamelessly borrowed from jQuery's [implementation](https://github.com/jquery/jquery/blob/master/src/css/hiddenVisibleSelectors.js#L12) of it.