### PR TITLE
Twitter embed readinglist

### DIFF
--- a/elements/bulbs-reading-list/components/bulbs-reading-list-item.js
+++ b/elements/bulbs-reading-list/components/bulbs-reading-list-item.js
@@ -126,9 +126,6 @@ class BulbsReadingListItem extends BulbsHTMLElement {
     this.isLoaded = true;
     this.fetchPending = false;
     this.dataset.loadStatus = 'loaded';
-    // if ($('blockquote.twitter-tweet')) {
-    //   twttr.widgets.load();
-    // }
     if (window.twttr) {
       twttr.widgets.load();
     };

--- a/elements/bulbs-reading-list/components/bulbs-reading-list-item.js
+++ b/elements/bulbs-reading-list/components/bulbs-reading-list-item.js
@@ -126,6 +126,9 @@ class BulbsReadingListItem extends BulbsHTMLElement {
     this.isLoaded = true;
     this.fetchPending = false;
     this.dataset.loadStatus = 'loaded';
+    if ($('blockquote.twitter-tweet')) {
+      twttr.widgets.load();
+    }
   }
 
   handleLoadContentError (response) {

--- a/elements/bulbs-reading-list/components/bulbs-reading-list-item.js
+++ b/elements/bulbs-reading-list/components/bulbs-reading-list-item.js
@@ -126,9 +126,10 @@ class BulbsReadingListItem extends BulbsHTMLElement {
     this.isLoaded = true;
     this.fetchPending = false;
     this.dataset.loadStatus = 'loaded';
+
     if (window.twttr) {
-      twttr.widgets.load();
-    };
+      window.twttr.widgets.load();
+    }
   }
 
   handleLoadContentError (response) {

--- a/elements/bulbs-reading-list/components/bulbs-reading-list-item.js
+++ b/elements/bulbs-reading-list/components/bulbs-reading-list-item.js
@@ -126,9 +126,12 @@ class BulbsReadingListItem extends BulbsHTMLElement {
     this.isLoaded = true;
     this.fetchPending = false;
     this.dataset.loadStatus = 'loaded';
-    if ($('blockquote.twitter-tweet')) {
+    // if ($('blockquote.twitter-tweet')) {
+    //   twttr.widgets.load();
+    // }
+    if (window.twttr) {
       twttr.widgets.load();
-    }
+    };
   }
 
   handleLoadContentError (response) {

--- a/elements/bulbs-reading-list/components/bulbs-reading-list-item.test.js
+++ b/elements/bulbs-reading-list/components/bulbs-reading-list-item.test.js
@@ -142,8 +142,8 @@ describe('BulbsReadingListItem', () => {
     beforeEach(() => {
       window.twttr = {
         widgets: {
-          load: function() {}
-        }
+          load: () => {},
+        },
       };
       sandbox.stub(subject, 'fillContent');
       sandbox.stub(window.twttr.widgets, 'load');
@@ -165,9 +165,10 @@ describe('BulbsReadingListItem', () => {
       expect(subject.fetchPending).to.be.false;
     });
 
-    it('tries to load any twitter widgets', function() {
+    it('tries to load any twitter widgets', () => {
       expect(window.twttr.widgets.load.called).to.be.true;
     });
+
     it('sets load status', () => {
       expect(subject.dataset.loadStatus).to.eql('loaded');
     });

--- a/elements/bulbs-reading-list/components/bulbs-reading-list-item.test.js
+++ b/elements/bulbs-reading-list/components/bulbs-reading-list-item.test.js
@@ -140,20 +140,33 @@ describe('BulbsReadingListItem', () => {
 
   describe('#handleLoadContentComplete', () => {
     beforeEach(() => {
+      window.twttr = {
+        widgets: {
+          load: function() {}
+        }
+      };
       sandbox.stub(subject, 'fillContent');
+      sandbox.stub(window.twttr.widgets, 'load');
       subject.handleLoadContentComplete();
     });
     afterEach(() => {
       sandbox.restore();
     });
+
     it('calls fillContent', () => {
       expect(subject.fillContent).to.be.called.once;
     });
+
     it('sets subject.isLoaded', () => {
       expect(subject.isLoaded).to.be.true;
     });
+
     it('sets subject.fetchPending', () => {
       expect(subject.fetchPending).to.be.false;
+    });
+
+    it('tries to load any twitter widgets', function() {
+      expect(window.twttr.widgets.load.called).to.be.true;
     });
     it('sets load status', () => {
       expect(subject.dataset.loadStatus).to.eql('loaded');

--- a/elements/bulbs-video/elements/meta/components/root.test.js
+++ b/elements/bulbs-video/elements/meta/components/root.test.js
@@ -84,7 +84,7 @@ describe('<bulbs-video-meta> <VideoMetaRoot>', () => {
         </bulbs-ellipsize>
       );
     });
-  })
+  });
 
   context('with a video', () => {
     beforeEach(() => {


### PR DESCRIPTION
@spra85 this looks like it's working! @theonion/front-end 

**Background**
Twitter embeds on articles that come after first one in the newswire reading list were not loading properly (they were just sitting there in blockquotes)

**Fix**
Added a twitter widget load (https://dev.twitter.com/web/javascript/initialization) into bulbs-reading-list-item.js to activate when the new article is loaded.

**Test Link**
http://twitter-embed.test.avclub.com/
It's tricky to test bc you have to get to an article with an embedded tweet in the newswire reading list (not the first article, those were working fine).. it's probably easiest to just embed a tweet into whatever article is second when you look at it (I'm not sure if the database will update overnight?)