### PR TITLE
Add some GA values to pdf-object fallback

### DIFF
--- a/elements/bulbs-pdfobject/bulbs-pdfobject-examples.js
+++ b/elements/bulbs-pdfobject/bulbs-pdfobject-examples.js
@@ -7,8 +7,8 @@ let examples = {
       render: () => {
         return `
           <bulbs-pdfobject 
-            src="https://s3.amazonaws.com/onionstatic/onion/custom/trump-docs/TD-Day1-TrumpAirForceOne.pdf" 
-            poster="https://s3.amazonaws.com/onionstatic/onion/custom/trump-docs/af1.png">
+            src="https://assets2.onionstatic.com/onion/custom/trump-docs/scans/01-Donald-Trump/1-Trump_Encrypted_Emails_SCAN.pdf" 
+            poster="https://assets2.onionstatic.com/onion/custom/trump-docs/poster/01-Donald-Trump/1-Trump_Encrypted_Emails_POSTER.png">
           </bulbs-pdfobject>
         `;
       },

--- a/elements/bulbs-pdfobject/bulbs-pdfobject.js
+++ b/elements/bulbs-pdfobject/bulbs-pdfobject.js
@@ -21,7 +21,7 @@ class BulbsPDFObject extends BulbsHTMLElement {
   embedPDF () {
     let poster = this.getAttribute('poster');
     let options = {
-      fallbackLink: `<a href='[url]' data-track-category="SF: Trump Docs 2017" data-track-action="Embed Fallback" data-track-label='[url]'><div class="fallback-btn">Tap to explore document</div><img src="${poster}"></a>`,
+      fallbackLink: `<a href='[url]' data-track-action="Embed Fallback" data-track-label='[url]'><div class="fallback-btn">Tap to explore document</div><img src="${poster}"></a>`,
     };
     PDFObject.embed(this.getAttribute('src'), this, options);
     InViewMonitor.remove(this);

--- a/elements/bulbs-pdfobject/bulbs-pdfobject.js
+++ b/elements/bulbs-pdfobject/bulbs-pdfobject.js
@@ -21,7 +21,7 @@ class BulbsPDFObject extends BulbsHTMLElement {
   embedPDF () {
     let poster = this.getAttribute('poster');
     let options = {
-      fallbackLink: `<a href='[url]'><div class="fallback-btn">Tap to explore document</div><img src="${poster}"></a>`,
+      fallbackLink: `<a href='[url]' data-track-category="SF: Trump Docs 2017" data-track-action="Embed Fallback" data-track-label='[url]'><div class="fallback-btn">Tap to explore document</div><img src="${poster}"></a>`,
     };
     PDFObject.embed(this.getAttribute('src'), this, options);
     InViewMonitor.remove(this);


### PR DESCRIPTION
Will need to revisit to make `data-track-category` dynamic. But it is outside the scope of the request for Trump Docs GA events.  Since the PDFs have already been ingested in the CMS it would require updating all 80+ entries by passing the value in through the element. The end result of this work is it gives us some sort of metric with actual user interactions with the PDF. @theonion/front-end 