### PR TITLE
minor video css tweaks

### DIFF
--- a/elements/bulbs-video/player-skin-overrides.scss
+++ b/elements/bulbs-video/player-skin-overrides.scss
@@ -69,9 +69,13 @@
   }
   .jw-icon-volume {
     max-width: 1.75em;
+		right: .8em;
 
+		.jw-overlay {
+			left: 2em;
+		}
     :first-child {
-      bottom: .2em !important;
+      bottom: .6em !important;
     }
   }
   .jw-icon-tooltip .jw-active-option {
@@ -146,7 +150,7 @@
   }
   .jw-controlbar {
     padding: 22px 0.2em 0;
-    
+
     .jw-controlbar-center-group {
       position: relative
     }


### PR DESCRIPTION
# the bug 🐛 

was bothering me - meant to get around to fixing this a while back but got caught up in kinja stuff.

before:
<img width="224" alt="screen shot 2017-05-24 at 12 25 38 pm" src="https://cloud.githubusercontent.com/assets/3171252/26416618/21bb1f04-407c-11e7-9174-d73d13309387.png">

now:
<img width="192" alt="screen shot 2017-05-24 at 12 25 20 pm" src="https://cloud.githubusercontent.com/assets/3171252/26416624/29938608-407c-11e7-82e9-d9111cadf6d9.png">

omni pr: https://github.com/theonion/omni/pull/1231

# test
 
http://video-player-vol-fix.test.avclub.com/video/legendary-wwe-announcer-jim-ross-reflects-great-mo-255801