### PR TITLE
Creative size

### DIFF
--- a/elements/bulbs-video/components/revealed.js
+++ b/elements/bulbs-video/components/revealed.js
@@ -55,6 +55,9 @@ export default class Revealed extends React.Component {
     let specialCoverage = this.props.targetSpecialCoverage || 'None';
     let autoplayInViewBool = typeof this.props.autoplayInView === 'string';
 
+    // Allowing creativeSize to be passed in in root.js
+    let creativeSize = this.props.creativeSize;
+
     let videoAdConfig = 'None';
     if (this.props.disableAds || this.props.video.disable_ads) {
       videoAdConfig = 'disable-ads';
@@ -78,6 +81,8 @@ export default class Revealed extends React.Component {
       BULBS_ELEMENTS_ONIONSTUDIOS_GA_ID,
       dimensions
     );
+
+
 
     // Making assignment copies here so we can mutate object structure.
     let videoMeta = Object.assign({}, this.props.video);
@@ -171,7 +176,7 @@ export default class Revealed extends React.Component {
     let type;
 
     // See docs (https://support.google.com/dfp_premium/answer/1068325?hl=en) for param info
-    baseUrl += '?sz=640x480';
+    baseUrl += `?sz=${this.props.creativeSize}`;
     baseUrl += `&iu=/4246/${window.Bulbs.settings.DFP_SITE_CODE}`;
     baseUrl += '&impl=s';
     baseUrl += '&gdfp_req=1';
@@ -361,6 +366,7 @@ Revealed.propTypes = {
   autoplay: PropTypes.bool,
   autoplayInView: PropTypes.string,
   autoplayNext: PropTypes.bool,
+  creativeSize: PropTypes.object.string,
   controller: PropTypes.object.isRequired,
   defaultCaptions: PropTypes.bool,
   disableAds: PropTypes.bool,

--- a/elements/bulbs-video/elements/rail-player/components/root.js
+++ b/elements/bulbs-video/elements/rail-player/components/root.js
@@ -32,7 +32,7 @@ export default class Root extends React.Component {
           <Revealed
             disableSharing={true}
             muted={true}
-            creativeSize='400x300'
+            creativeSize='640x480'
             targetHostChannel='right_rail'
             defaultCaptions={true}
             {...this.props}

--- a/elements/bulbs-video/elements/rail-player/components/root.js
+++ b/elements/bulbs-video/elements/rail-player/components/root.js
@@ -32,6 +32,7 @@ export default class Root extends React.Component {
           <Revealed
             disableSharing={true}
             muted={true}
+            creativeSize='400x300'
             targetHostChannel='right_rail'
             defaultCaptions={true}
             {...this.props}
@@ -55,6 +56,7 @@ Root.displayName = 'RailPlayerRoot';
 
 Root.propTypes = {
   channel: PropTypes.string,
+  creativeSize: PropTypes.string,
   recircUrl: PropTypes.string.isRequired,
   targetCampaignId: PropTypes.string,
   targetSpecialCoverage: PropTypes.string,

--- a/elements/bulbs-video/elements/rail-player/rail-player.js
+++ b/elements/bulbs-video/elements/rail-player/rail-player.js
@@ -60,6 +60,7 @@ Object.assign(RailPlayer, {
   },
   propTypes: {
     channel: PropTypes.string.isRequired,
+    creativeSize: PropTypes.string,
     recircUrl: PropTypes.string.isRequired,
     src: PropTypes.string.isRequired,
     targetCampaignId: PropTypes.string,


### PR DESCRIPTION
**Purpose**
Add ability to pass in a VAST video size for the rail unit rather than have it hardcoded

**Ticket**
https://app.asana.com/0/342156387987716/354541582224232

@spra85 I'm not sure how to do like a test link, but I was testing it in the bulbs local webpack on the rail-player with campaign and it is working there..

Also not sure how the tests work yet, but figured I'd put this up here for now!