### PR TITLE
Embed Auto-resizing fixes

### DIFF
--- a/elements/bulbs-clickventure/bulbs-clickventure.js
+++ b/elements/bulbs-clickventure/bulbs-clickventure.js
@@ -21,7 +21,7 @@ class BulbsClickventure extends BulbsHTMLElement {
     $element.on('clickventure-page-change', fireAnalytics);
 
     // Embedded CVs can resize their parent frame
-    resizeParentFrame(document.body.clientHeight);
+    resizeParentFrame()
   }
 }
 

--- a/elements/bulbs-clickventure/bulbs-clickventure.js
+++ b/elements/bulbs-clickventure/bulbs-clickventure.js
@@ -21,7 +21,7 @@ class BulbsClickventure extends BulbsHTMLElement {
     $element.on('clickventure-page-change', fireAnalytics);
 
     // Embedded CVs can resize their parent frame
-    resizeParentFrame()
+    resizeParentFrame();
   }
 }
 

--- a/elements/bulbs-clickventure/clickventure.js
+++ b/elements/bulbs-clickventure/clickventure.js
@@ -5,6 +5,7 @@ import '!imports?this=>window!velocity-animate/velocity.ui';
 import {
   InViewMonitor,
   prepReadingListAnalytics,
+  resizeParentFrame,
 } from 'bulbs-elements/util';
 
 velocity
@@ -205,7 +206,12 @@ export default class Clickventure {
           duration: 300,
           stagger: 100,
         });
-        window.picturefill(newNode);
+        if (window.parent) {
+          // We're embedded, update parent frame size
+          resizeParentFrame();
+        } else {
+          window.picturefill(newNode);
+        }
       }),
     });
     this.adRefresh();

--- a/elements/bulbs-quiz/bulbs-quiz.js
+++ b/elements/bulbs-quiz/bulbs-quiz.js
@@ -56,7 +56,7 @@ class BulbsQuiz extends BulbsHTMLElement {
     this.quiz.setup();
 
     // Embedded quizzes can resize their parent frame
-    resizeParentFrame(document.body.clientHeight);
+    resizeParentFrame();
   }
 }
 

--- a/elements/bulbs-quiz/cosmode-quiz.js
+++ b/elements/bulbs-quiz/cosmode-quiz.js
@@ -1,3 +1,4 @@
+import { resizeParentFrame } from 'bulbs-elements/util';
 import {
   sendResultAnalytics,
   OUTCOME_REVEAL_DURATION,
@@ -84,6 +85,9 @@ export default class CosmodeQuiz {
       if (this.options.sendAnalytics) {
         sendResultAnalytics(bestOutcome);
       }
+
+      // Resize parent frame (if embed)
+      resizeParentFrame();
     }
   }
 }

--- a/elements/bulbs-quiz/cosmode-quiz.js
+++ b/elements/bulbs-quiz/cosmode-quiz.js
@@ -72,9 +72,11 @@ export default class CosmodeQuiz {
 
     if (bestOutcome) {
       $('.outcomes', this.element).show();
+      resizeParentFrame();
       bestOutcome.show(OUTCOME_REVEAL_DURATION, () => {
         window.picturefill();
         quiz.element.addClass('completed');
+        resizeParentFrame();
       });
 
       $(window).scrollTo(bestOutcome, {
@@ -85,9 +87,6 @@ export default class CosmodeQuiz {
       if (this.options.sendAnalytics) {
         sendResultAnalytics(bestOutcome);
       }
-
-      // Resize parent frame (if embed)
-      resizeParentFrame();
     }
   }
 }

--- a/elements/bulbs-quiz/multiple-choice-quiz.js
+++ b/elements/bulbs-quiz/multiple-choice-quiz.js
@@ -100,10 +100,17 @@ export default class MultipleChoiceQuiz {
 
     // If there's an outcome, show it.
     if (outcomeId) {
+      console.log('Found Output ID', outcomeId);
       $('.outcomes', this.element).show();
       bestOutcome.show(OUTCOME_REVEAL_DURATION, () => {
-        window.picturefill();
+        if (!window.parent) {
+          console.log('Trigger picturefill (not an embed)');
+          window.picturefill();
+        }
         quiz.element.addClass('completed');
+
+        // Resize parent frame (if embed)
+        resizeParentFrame();
       });
 
       $(window).scrollTo(bestOutcome, {
@@ -116,9 +123,6 @@ export default class MultipleChoiceQuiz {
       if (this.options.sendAnalytics) {
         sendResultAnalytics(bestOutcome);
       }
-
-      // Resize parent frame (if embed)
-      resizeParentFrame();
     }
   }
 }

--- a/elements/bulbs-quiz/multiple-choice-quiz.js
+++ b/elements/bulbs-quiz/multiple-choice-quiz.js
@@ -102,6 +102,10 @@ export default class MultipleChoiceQuiz {
     if (outcomeId) {
       console.log('Found Output ID', outcomeId);
       $('.outcomes', this.element).show();
+
+      console.log('call resizeParentFrame() 1', outcomeId);
+      resizeParentFrame();
+
       bestOutcome.show(OUTCOME_REVEAL_DURATION, () => {
         if (!window.parent) {
           console.log('Trigger picturefill (not an embed)');
@@ -110,6 +114,7 @@ export default class MultipleChoiceQuiz {
         quiz.element.addClass('completed');
 
         // Resize parent frame (if embed)
+        console.log('call resizeParentFrame() 2', outcomeId);
         resizeParentFrame();
       });
 

--- a/elements/bulbs-quiz/multiple-choice-quiz.js
+++ b/elements/bulbs-quiz/multiple-choice-quiz.js
@@ -100,21 +100,14 @@ export default class MultipleChoiceQuiz {
 
     // If there's an outcome, show it.
     if (outcomeId) {
-      console.log('Found Output ID', outcomeId);
       $('.outcomes', this.element).show();
-
-      console.log('call resizeParentFrame() 1', outcomeId);
       resizeParentFrame();
-
       bestOutcome.show(OUTCOME_REVEAL_DURATION, () => {
         if (!window.parent) {
-          console.log('Trigger picturefill (not an embed)');
           window.picturefill();
         }
         quiz.element.addClass('completed');
 
-        // Resize parent frame (if embed)
-        console.log('call resizeParentFrame() 2', outcomeId);
         resizeParentFrame();
       });
 

--- a/elements/bulbs-quiz/multiple-choice-quiz.js
+++ b/elements/bulbs-quiz/multiple-choice-quiz.js
@@ -1,3 +1,4 @@
+import { resizeParentFrame } from 'bulbs-elements/util';
 import {
   sendResultAnalytics,
   OUTCOME_REVEAL_DURATION,
@@ -115,6 +116,9 @@ export default class MultipleChoiceQuiz {
       if (this.options.sendAnalytics) {
         sendResultAnalytics(bestOutcome);
       }
+
+      // Resize parent frame (if embed)
+      resizeParentFrame();
     }
   }
 }

--- a/elements/bulbs-quiz/tally-quiz.js
+++ b/elements/bulbs-quiz/tally-quiz.js
@@ -44,9 +44,11 @@ export default class TallyQuiz {
 
     if (bestOutcome) {
       $('.outcomes', this.element).show();
+      resizeParentFrame();
       bestOutcome.show(OUTCOME_REVEAL_DURATION, () => {
         window.picturefill();
         quiz.element.addClass('completed');
+        resizeParentFrame();
       });
 
       $(window).scrollTo(bestOutcome, {
@@ -57,9 +59,6 @@ export default class TallyQuiz {
       if (this.options.sendAnalytics) {
         sendResultAnalytics(bestOutcome);
       }
-
-      // Resize parent frame (if embed)
-      resizeParentFrame();
     }
   }
 }

--- a/elements/bulbs-quiz/tally-quiz.js
+++ b/elements/bulbs-quiz/tally-quiz.js
@@ -1,3 +1,4 @@
+import { resizeParentFrame } from 'bulbs-elements/util';
 import {
   sendResultAnalytics,
   OUTCOME_REVEAL_DURATION,
@@ -56,6 +57,9 @@ export default class TallyQuiz {
       if (this.options.sendAnalytics) {
         sendResultAnalytics(bestOutcome);
       }
+
+      // Resize parent frame (if embed)
+      resizeParentFrame();
     }
   }
 }

--- a/elements/bulbs-quiz/test-quiz.js
+++ b/elements/bulbs-quiz/test-quiz.js
@@ -80,9 +80,11 @@ export default class TestQuiz {
     }
     if (bestOutcome) {
       $('.outcomes', this.element).show();
+      resizeParentFrame();
       bestOutcome.show(OUTCOME_REVEAL_DURATION, () => {
         window.picturefill();
         quiz.element.addClass('completed');
+        resizeParentFrame();
       });
       $(window).scrollTo(bestOutcome, {
         duration: OUTCOME_REVEAL_DURATION,
@@ -93,9 +95,6 @@ export default class TestQuiz {
       if (this.options.sendAnalytics) {
         sendResultAnalytics(bestOutcome);
       }
-
-      // Resize parent frame (if embed)
-      resizeParentFrame();
     }
   }
 }

--- a/elements/bulbs-quiz/test-quiz.js
+++ b/elements/bulbs-quiz/test-quiz.js
@@ -1,3 +1,4 @@
+import { resizeParentFrame } from 'bulbs-elements/util';
 import {
   sendResultAnalytics,
   OUTCOME_REVEAL_DURATION,
@@ -92,6 +93,9 @@ export default class TestQuiz {
       if (this.options.sendAnalytics) {
         sendResultAnalytics(bestOutcome);
       }
+
+      // Resize parent frame (if embed)
+      resizeParentFrame();
     }
   }
 }

--- a/elements/bulbs-video/components/revealed.test.js
+++ b/elements/bulbs-video/components/revealed.test.js
@@ -147,7 +147,7 @@ describe('<bulbs-video> <Revealed>', () => {
           targetHostChannel: 'host_channel',
           videojs_options: {},
           twitterHandle: 'twitter',
-          autoplay: "",
+          autoplay: '',
           autoplayNext: true,
           disableAds: true,
           embedded: true,

--- a/lib/bulbs-elements/util/resize-parent-frame.js
+++ b/lib/bulbs-elements/util/resize-parent-frame.js
@@ -7,8 +7,6 @@ function sendResizeMessage () {
 
   let height = document.body.clientHeight;
 
-  console.log('Resize parent frame', height);
-
   window.parent.postMessage({
     kinja: {
       sourceUrl,

--- a/lib/bulbs-elements/util/resize-parent-frame.js
+++ b/lib/bulbs-elements/util/resize-parent-frame.js
@@ -5,11 +5,15 @@ function sendResizeMessage () {
   // Remove any anchor tags
   let sourceUrl = window.location.href.split('#')[0];
 
+  let height = document.body.clientHeight;
+
+  console.log('Resize parent frame', height);
+
   window.parent.postMessage({
     kinja: {
       sourceUrl,
       resizeFrame: {
-        height: document.body.clientHeight,
+        height,
       },
     },
   }, '*');

--- a/lib/bulbs-elements/util/resize-parent-frame.js
+++ b/lib/bulbs-elements/util/resize-parent-frame.js
@@ -15,7 +15,7 @@ function sendResizeMessage () {
   }, '*');
 }
 
-export default function resizeParentFrame() {
+export default function resizeParentFrame () {
 
   if (window.parent) {
     // We're in a child frame (e.g. an embed)

--- a/lib/bulbs-elements/util/resize-parent-frame.js
+++ b/lib/bulbs-elements/util/resize-parent-frame.js
@@ -1,19 +1,30 @@
 // Resize a (Kinja) parent frame, using Kinja's parent notification support.
 
-export default function resizeParentFrame (height) {
+function sendResizeMessage () {
+
+  // Remove any anchor tags
+  let sourceUrl = window.location.href.split('#')[0];
+
+  window.parent.postMessage({
+    kinja: {
+      sourceUrl,
+      resizeFrame: {
+        height: document.body.clientHeight,
+      },
+    },
+  }, '*');
+}
+
+export default function resizeParentFrame() {
+
   if (window.parent) {
     // We're in a child frame (e.g. an embed)
 
-    // Remove any anchor tags
-    let sourceUrl = window.location.href.split('#')[0];
-
-    window.parent.postMessage({
-      kinja: {
-        sourceUrl,
-        resizeFrame: {
-          height,
-        },
-      },
-    }, '*');
+    // Fire immediately
+    sendResizeMessage();
+    // This is a hack to ensure that parent frame correctly resizes after responsive images are loaded.
+    setTimeout(sendResizeMessage, 1500);
+    // And one catch-all for slower connections
+    setTimeout(sendResizeMessage, 10000);
   }
 }


### PR DESCRIPTION
Fix a few issues resizing Kinja CV and Quiz embeds:

- Resize quizzes on completion
- Resize Clickventures on node change 
- resizeParentFrame() now triggers additional re-sizes messages after timeouts, to allow images to load
- prevent misc `picturefill()` errors on embeds
- Fix misc unrelated Lint error in `revealed.test.js`

## Test Links:

[Embedded Quiz](https://mparent61.kinja.com/test-embed-auto-sizing-1823657233)
[Embedded Clickventure](https://mparent61.kinja.com/clickventure-embed-auto-sizing-1823732820)

[Site Quizzes Still Work](http://bulbs-resize-fixes.test.clickhole.com/r/236)
[Site Clickventures Still Work](http://bulbs-resize-fixes.test.clickhole.com/r/1828)