### PR TITLE
Fix ./scripts/tag-and-release

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,5 +143,8 @@
     "react-addons-test-utils": "^15.6.2",
     "react-dom": "^15.6.2",
     "react-test-renderer": "^15.6.2"
+  },
+  "engines": {
+    "node": ">=9.0.0"
   }
 }

--- a/webpack.base.js
+++ b/webpack.base.js
@@ -179,10 +179,10 @@ exports.loaders = {
 
 exports.config = {
   entry: entries,
-  externals: [
-    'child_process',
-    'fs'
-  ],
+  node: {
+    'child_process': 'empty',
+    'fs': 'empty'
+  },
   output: {
     path: path.join(__dirname, 'dist'),
     filename: '[name].js',

--- a/webpack.base.js
+++ b/webpack.base.js
@@ -179,6 +179,10 @@ exports.loaders = {
 
 exports.config = {
   entry: entries,
+  externals: [
+    'child_process',
+    'fs'
+  ],
   output: {
     path: path.join(__dirname, 'dist'),
     filename: '[name].js',


### PR DESCRIPTION
This should fix the ./scripts/tag-and-release script issues with upgraded Node version; also forces a Node engine version so it's clear what version of Node the script is known to work with. 