### PR TITLE
Fix embed check

### DIFF
--- a/elements/bulbs-clickventure/clickventure.js
+++ b/elements/bulbs-clickventure/clickventure.js
@@ -206,12 +206,8 @@ export default class Clickventure {
           duration: 300,
           stagger: 100,
         });
-        if (window.parent) {
-          // We're embedded, update parent frame size
-          resizeParentFrame();
-        } else {
-          window.picturefill(newNode);
-        }
+        window.picturefill(newNode);
+        resizeParentFrame();
       }),
     });
     this.adRefresh();

--- a/elements/bulbs-quiz/multiple-choice-quiz.js
+++ b/elements/bulbs-quiz/multiple-choice-quiz.js
@@ -103,9 +103,7 @@ export default class MultipleChoiceQuiz {
       $('.outcomes', this.element).show();
       resizeParentFrame();
       bestOutcome.show(OUTCOME_REVEAL_DURATION, () => {
-        if (!window.parent) {
-          window.picturefill();
-        }
+        window.picturefill();
         quiz.element.addClass('completed');
 
         resizeParentFrame();

--- a/lib/bulbs-elements/util/in-iframe.js
+++ b/lib/bulbs-elements/util/in-iframe.js
@@ -1,0 +1,9 @@
+// Cross-browser check to determine if we're embedded inside an Iframe
+export default function inIframe () {
+  try {
+    return window.self !== window.top;
+  }
+  catch (e) {
+    return true;
+  }
+}

--- a/lib/bulbs-elements/util/index.js
+++ b/lib/bulbs-elements/util/index.js
@@ -11,6 +11,7 @@ import filterBadResponse from './filter-bad-response';
 import getAnalyticsManager from './get-analytics-manager';
 import getResponseJSON from './get-response-json';
 import getResponseText from './get-response-text';
+import inIframe from './in-iframe';
 import iterateObject from './iterate-object';
 import loadOnDemand from './load-on-demand';
 import makeRequest from './make-request';
@@ -44,6 +45,7 @@ module.exports = {
   getResponseText,
   getScrollOffset,
   getWindowDimensions,
+  inIframe,
   isNumericString,
   iterateObject,
   loadOnDemand,

--- a/lib/bulbs-elements/util/resize-parent-frame.js
+++ b/lib/bulbs-elements/util/resize-parent-frame.js
@@ -1,3 +1,5 @@
+import inIframe from './in-iframe';
+
 // Resize a (Kinja) parent frame, using Kinja's parent notification support.
 
 function sendResizeMessage () {
@@ -19,7 +21,7 @@ function sendResizeMessage () {
 
 export default function resizeParentFrame () {
 
-  if (window.top !== window) {
+  if (inIframe()) {
     // We're in a child frame (e.g. an embed)
 
     // Fire immediately

--- a/lib/bulbs-elements/util/resize-parent-frame.js
+++ b/lib/bulbs-elements/util/resize-parent-frame.js
@@ -19,7 +19,7 @@ function sendResizeMessage () {
 
 export default function resizeParentFrame () {
 
-  if (window.parent) {
+  if (window.top !== window) {
     // We're in a child frame (e.g. an embed)
 
     // Fire immediately


### PR DESCRIPTION
Similar fixes for buggy "is embedded" check (see https://github.com/theonion/omni/pull/1400).

(Mirrors what JW does too)

- Adds new `inIframe` utility method (https://stackoverflow.com/a/326076/8903106)
- Removes some embed checks around `window.picturefill()`, we'll just stub this out for embeds (much simpler way to avoid many `picturefill` JS errors). 