### PR TITLE
Quz embeds resize parent frame whenever they expand

### DIFF
--- a/elements/bulbs-quiz/cosmode-quiz.js
+++ b/elements/bulbs-quiz/cosmode-quiz.js
@@ -23,6 +23,7 @@ export default class CosmodeQuiz {
           $elQuestion.attr('data-unanswered', 'false');
           $('.post-answer-body', $elQuestion).show(100, function () {
             window.picturefill();
+            resizeParentFrame();
           });
         });
       });

--- a/elements/bulbs-quiz/multiple-choice-quiz.js
+++ b/elements/bulbs-quiz/multiple-choice-quiz.js
@@ -23,6 +23,7 @@ export default class MultipleChoiceQuiz {
           $elQuestion.attr('data-unanswered', 'false');
           $('.post-answer-body', $elQuestion).show(100, function () {
             window.picturefill();
+            resizeParentFrame();
           });
         });
       });
@@ -105,7 +106,6 @@ export default class MultipleChoiceQuiz {
       bestOutcome.show(OUTCOME_REVEAL_DURATION, () => {
         window.picturefill();
         quiz.element.addClass('completed');
-
         resizeParentFrame();
       });
 

--- a/elements/bulbs-quiz/test-quiz.js
+++ b/elements/bulbs-quiz/test-quiz.js
@@ -28,6 +28,7 @@ export default class TestQuiz {
           // reveal explanation for the the selected answer only
           $('.answer-explanation', elAnswer).show(100, () => {
             window.picturefill();
+            resizeParentFrame();
           });
           let revealClass = quiz.revealAllAnswers ? 'reveal-all-answers' : 'reveal-answer';
           $($elQuestion).addClass(revealClass);
@@ -35,6 +36,7 @@ export default class TestQuiz {
           // reveal post-answer content
           $('.post-answer-body', $elQuestion).show(100, () => {
             window.picturefill();
+            resizeParentFrame();
           });
         });
       });


### PR DESCRIPTION
## What?

Was missing a `resizeParentFrame()` calls, which should match wherever we call `window.picturefill()`.  (Maybe there's a cleaner way to inject this call inside `window.picturefill()`, but this should cover all cases.)

## Test Embed:

Note how this "Test Quiz" embed now correctly expands whenever you click any answer.

https://mparent61.kinja.com/another-quiz-embed-1824001702