### PR TITLE
Always resize parent on Quiz input change

### DIFF
--- a/elements/bulbs-quiz/cosmode-quiz.js
+++ b/elements/bulbs-quiz/cosmode-quiz.js
@@ -21,6 +21,7 @@ export default class CosmodeQuiz {
         $('input', elAnswer).change(() => {
           // reveal post-answer content
           $elQuestion.attr('data-unanswered', 'false');
+          resizeParentFrame();
           $('.post-answer-body', $elQuestion).show(100, function () {
             window.picturefill();
             resizeParentFrame();
@@ -45,6 +46,7 @@ export default class CosmodeQuiz {
     // Make sure they answered all the questions
     if (formData.length !== numQuestions) {
       $('.check-outcome', this.element).show();
+      resizeParentFrame();
       let firstUnanswered = $('.question[data-unanswered="true"]', this.element)[0];
       $(window).scrollTo(firstUnanswered, { duration: 250 });
       return false;

--- a/elements/bulbs-quiz/multiple-choice-quiz.js
+++ b/elements/bulbs-quiz/multiple-choice-quiz.js
@@ -21,6 +21,7 @@ export default class MultipleChoiceQuiz {
         $('input', elAnswer).change(() => {
           // reveal post-answer content
           $elQuestion.attr('data-unanswered', 'false');
+          resizeParentFrame();
           $('.post-answer-body', $elQuestion).show(100, function () {
             window.picturefill();
             resizeParentFrame();
@@ -45,6 +46,7 @@ export default class MultipleChoiceQuiz {
     // Make sure they answered all the questions
     if (formData.length !== numQuestions) {
       $('.check-outcome', this.element).show();
+      resizeParentFrame();
       let firstUnanswered = $('.question[data-unanswered="true"]', this.element)[0];
       $(window).scrollTo(firstUnanswered, { duration: 250 });
       return false;

--- a/elements/bulbs-quiz/tally-quiz.js
+++ b/elements/bulbs-quiz/tally-quiz.js
@@ -13,6 +13,16 @@ export default class TallyQuiz {
   }
 
   setup () {
+
+    $('.question', this.element).each(function (i, elQuestion) {
+      let $elQuestion = $(elQuestion);
+      $('.answer', $elQuestion).each((n, elAnswer) => {
+        $('input', elAnswer).change(() => {
+          resizeParentFrame();
+        });
+      });
+    });
+
     $('form', this.element).submit((event) => {
       event.preventDefault();
       $('.check-outcome', this.element).hide();

--- a/elements/bulbs-quiz/test-quiz.js
+++ b/elements/bulbs-quiz/test-quiz.js
@@ -32,6 +32,7 @@ export default class TestQuiz {
           });
           let revealClass = quiz.revealAllAnswers ? 'reveal-all-answers' : 'reveal-answer';
           $($elQuestion).addClass(revealClass);
+          resizeParentFrame();
 
           // reveal post-answer content
           $('.post-answer-body', $elQuestion).show(100, () => {
@@ -57,6 +58,7 @@ export default class TestQuiz {
     // Make sure they answered all the questions
     if (numAnswered !== numQuestions) {
       $('.check-outcome', this.element).show();
+      resizeParentFrame();
       let firstUnanswered = $('.question[data-unanswered="true"]', this.element)[0];
       $(window).scrollTo(firstUnanswered, { duration: 250 });
       return false;


### PR DESCRIPTION
# What?

Adds more `resizeParentFrame()` calls whenever inputs change. Necessary b/c selecting an answer makes font bold/larger and can trigger re-flow to new line, pushing down "Get Results" button and increasing page height. 

# Testing

Make your browser window really narrow, and select quiz answers. Note how height is resized and you can always see the submit button at the bottom.

https://clickholequiz.kinja.com/which-one-of-my-enchanted-marionettes-that-love-north-k-1824212270