### PR TITLE
Fix more Clickhole embed resizing issues

### DIFF
--- a/elements/bulbs-clickventure/bulbs-clickventure.js
+++ b/elements/bulbs-clickventure/bulbs-clickventure.js
@@ -37,8 +37,8 @@ class BulbsClickventure extends BulbsHTMLElement {
 
     // Embedded CVs can resize their parent frame
     resizeParentFrame();
-    // Reize parent when iframe is resized
-    $(window).on('resize', resizeParentFrame)
+    // Resize parent when iframe is resized
+    $(window).on('resize', resizeParentFrame);
   }
 }
 

--- a/elements/bulbs-clickventure/bulbs-clickventure.js
+++ b/elements/bulbs-clickventure/bulbs-clickventure.js
@@ -37,6 +37,8 @@ class BulbsClickventure extends BulbsHTMLElement {
 
     // Embedded CVs can resize their parent frame
     resizeParentFrame();
+    // Reize parent when iframe is resized
+    $(window).on('resize', resizeParentFrame)
   }
 }
 

--- a/elements/bulbs-quiz/bulbs-quiz.js
+++ b/elements/bulbs-quiz/bulbs-quiz.js
@@ -57,6 +57,8 @@ class BulbsQuiz extends BulbsHTMLElement {
 
     // Embedded quizzes can resize their parent frame
     resizeParentFrame();
+    // Reize parent when iframe is resized
+    $(window).on('resize', resizeParentFrame)
   }
 }
 

--- a/elements/bulbs-quiz/bulbs-quiz.js
+++ b/elements/bulbs-quiz/bulbs-quiz.js
@@ -57,8 +57,8 @@ class BulbsQuiz extends BulbsHTMLElement {
 
     // Embedded quizzes can resize their parent frame
     resizeParentFrame();
-    // Reize parent when iframe is resized
-    $(window).on('resize', resizeParentFrame)
+    // Resize parent when iframe is resized
+    $(window).on('resize', resizeParentFrame);
   }
 }
 

--- a/elements/bulbs-quiz/cosmode-quiz.js
+++ b/elements/bulbs-quiz/cosmode-quiz.js
@@ -21,6 +21,7 @@ export default class CosmodeQuiz {
         $('input', elAnswer).change(() => {
           // reveal post-answer content
           $elQuestion.attr('data-unanswered', 'false');
+          resizeParentFrame();
           $('.post-answer-body', $elQuestion).show(100, function () {
             window.picturefill();
             resizeParentFrame();
@@ -45,6 +46,7 @@ export default class CosmodeQuiz {
     // Make sure they answered all the questions
     if (formData.length !== numQuestions) {
       $('.check-outcome', this.element).show();
+      resizeParentFrame();
       let firstUnanswered = $('.question[data-unanswered="true"]', this.element)[0];
       $(window).scrollTo(firstUnanswered, { duration: 250 });
       return false;

--- a/elements/bulbs-quiz/multiple-choice-quiz.js
+++ b/elements/bulbs-quiz/multiple-choice-quiz.js
@@ -21,6 +21,7 @@ export default class MultipleChoiceQuiz {
         $('input', elAnswer).change(() => {
           // reveal post-answer content
           $elQuestion.attr('data-unanswered', 'false');
+          resizeParentFrame();
           $('.post-answer-body', $elQuestion).show(100, function () {
             window.picturefill();
             resizeParentFrame();
@@ -45,6 +46,7 @@ export default class MultipleChoiceQuiz {
     // Make sure they answered all the questions
     if (formData.length !== numQuestions) {
       $('.check-outcome', this.element).show();
+      resizeParentFrame();
       let firstUnanswered = $('.question[data-unanswered="true"]', this.element)[0];
       $(window).scrollTo(firstUnanswered, { duration: 250 });
       return false;

--- a/elements/bulbs-quiz/tally-quiz.js
+++ b/elements/bulbs-quiz/tally-quiz.js
@@ -13,6 +13,16 @@ export default class TallyQuiz {
   }
 
   setup () {
+
+    $('.question', this.element).each(function (i, elQuestion) {
+      let $elQuestion = $(elQuestion);
+      $('.answer', $elQuestion).each((n, elAnswer) => {
+        $('input', elAnswer).change(() => {
+          resizeParentFrame();
+        });
+      });
+    });
+
     $('form', this.element).submit((event) => {
       event.preventDefault();
       $('.check-outcome', this.element).hide();

--- a/elements/bulbs-quiz/test-quiz.js
+++ b/elements/bulbs-quiz/test-quiz.js
@@ -32,6 +32,7 @@ export default class TestQuiz {
           });
           let revealClass = quiz.revealAllAnswers ? 'reveal-all-answers' : 'reveal-answer';
           $($elQuestion).addClass(revealClass);
+          resizeParentFrame();
 
           // reveal post-answer content
           $('.post-answer-body', $elQuestion).show(100, () => {
@@ -57,6 +58,7 @@ export default class TestQuiz {
     // Make sure they answered all the questions
     if (numAnswered !== numQuestions) {
       $('.check-outcome', this.element).show();
+      resizeParentFrame();
       let firstUnanswered = $('.question[data-unanswered="true"]', this.element)[0];
       $(window).scrollTo(firstUnanswered, { duration: 250 });
       return false;


### PR DESCRIPTION
# What?

More auto-resizing fixes for Kinja embeds.

Triggers parent resize event on:
1. Quiz + Clickventure 'resize' window events (i.e. changing browser width)
1. Quiz input `change` events (i.e. checking answers)


# Testing

### Quiz: 
1. Make screen narrow, notice how automatically re-sizes (and "Get Results" still visible)
2. Click on longer text answers to trigger re-flow to new line. Notice how re-sizes (and "Get Results" still visible)
https://mparent61.kinja.com/cosmo-quiz-wolverine-1824284821

### Clickventure: 
1. Make screen narrow, notice how automatically re-sizes (and "Get Results" still visible)
https://mparent61.kinja.com/clickventure-1824111481