### PR TITLE
Fix for vertical splitpic using the #load event

### DIFF
--- a/elements/bulbs-splitpic/bulbs-splitpic-examples.js
+++ b/elements/bulbs-splitpic/bulbs-splitpic-examples.js
@@ -129,6 +129,13 @@ let examples = {
         `;
       },
     },
+    'vertical slider': {
+      render () {
+        return `
+          <bulbs-splitpic bs-start-percent="0" bs-left-image="https://i.kinja-img.com/gawker-media/image/upload/szgkv27bpxqaglfnjupp" bs-right-image="https://i.kinja-img.com/gawker-media/image/upload/y32ehkc9tyoo4pywuhdl" bs-image-size="big" class="splitpic splitpic-vertical" orientation="vertical"><div class="splitpic-images size-big"><div class="splitpic-image inline splitpic-right-image image crop-original" data-crop="original"><img src="https://i.kinja-img.com/gawker-media/image/upload/y32ehkc9tyoo4pywuhdl"></div><div class="splitpic-image inline splitpic-left-image image crop-original" data-crop="original"><img src="https://i.kinja-img.com/gawker-media/image/upload/szgkv27bpxqaglfnjupp"></div><div class="splitpic-bar"></div><div class="splitpic-info"><span class="fa fa-arrow-left"></span> Slide<span class="fa fa-arrow-right"></span></div></div><p class="figcaption"></p></bulbs-splitpic>
+        `;
+      },
+    },
   },
 };
 

--- a/elements/bulbs-splitpic/splitpic.js
+++ b/elements/bulbs-splitpic/splitpic.js
@@ -127,7 +127,7 @@ export function SplitPicVertical (element) {
     setInitialPosition();
   }
   else {
-    img.load(setInitialPosition.bind(this));
+    $( document ).ready(setInitialPosition.bind(this));
   }
 
   el.on('touchmove touchstart', function (event) {


### PR DESCRIPTION
The #load event in jquery was removed in jquery 3.x (http://api.jquery.com/load-event/), so this removes the usage of it in VerticalSplitPic